### PR TITLE
start validating workchain inputs

### DIFF
--- a/aiida_lsmo/utils/__init__.py
+++ b/aiida_lsmo/utils/__init__.py
@@ -2,7 +2,7 @@
 """aiida-lsmo utils"""
 from .multiply_unitcell import check_resize_unit_cell
 from .other_utilities import aiida_dict_merge, dict_merge, aiida_cif_merge, aiida_structure_merge
-from .other_utilities import get_structure_from_cif, get_cif_from_structure, get_valid_dict
+from .other_utilities import get_structure_from_cif, get_cif_from_structure, get_valid_dict, validate_dict
 
 HARTREE2EV = 27.211399
 HARTREE2KJMOL = 2625.500

--- a/aiida_lsmo/utils/__init__.py
+++ b/aiida_lsmo/utils/__init__.py
@@ -2,7 +2,7 @@
 """aiida-lsmo utils"""
 from .multiply_unitcell import check_resize_unit_cell
 from .other_utilities import aiida_dict_merge, dict_merge, aiida_cif_merge, aiida_structure_merge
-from .other_utilities import get_structure_from_cif, get_cif_from_structure
+from .other_utilities import get_structure_from_cif, get_cif_from_structure, get_valid_dict
 
 HARTREE2EV = 27.211399
 HARTREE2KJMOL = 2625.500

--- a/aiida_lsmo/utils/__init__.py
+++ b/aiida_lsmo/utils/__init__.py
@@ -2,7 +2,7 @@
 """aiida-lsmo utils"""
 from .multiply_unitcell import check_resize_unit_cell
 from .other_utilities import aiida_dict_merge, dict_merge, aiida_cif_merge, aiida_structure_merge
-from .other_utilities import get_structure_from_cif, get_cif_from_structure, get_valid_dict, validate_dict
+from .other_utilities import get_structure_from_cif, get_cif_from_structure, validate_dict
 
 HARTREE2EV = 27.211399
 HARTREE2KJMOL = 2625.500

--- a/aiida_lsmo/utils/other_utilities.py
+++ b/aiida_lsmo/utils/other_utilities.py
@@ -92,3 +92,9 @@ def get_structure_from_cif(cifdata):
 def get_cif_from_structure(structuredata):
     """Convert CifData to StructureData maintaining the provenance."""
     return structuredata.get_cif()
+
+
+@calcfunction
+def get_valid_dict(dict_node, schema):
+    """Validate dictionary against schema and return Dict instance."""
+    return Dict(dict=schema(dict_node.get_dict()))

--- a/aiida_lsmo/utils/other_utilities.py
+++ b/aiida_lsmo/utils/other_utilities.py
@@ -95,12 +95,6 @@ def get_cif_from_structure(structuredata):
     return structuredata.get_cif()
 
 
-@calcfunction
-def get_valid_dict(dict_node, schema):
-    """Validate dictionary against schema and return Dict instance."""
-    return Dict(dict=schema(dict_node.get_dict()))
-
-
 def validate_dict(dict_node, port, schema):  # pylint: disable=unused-argument
     """Validate dictionary against schema.
 

--- a/aiida_lsmo/utils/other_utilities.py
+++ b/aiida_lsmo/utils/other_utilities.py
@@ -3,6 +3,7 @@
 
 import collections
 import ase
+from voluptuous import MultipleInvalid, Invalid
 from aiida.orm import Dict, CifData, StructureData
 from aiida.engine import calcfunction
 
@@ -98,3 +99,18 @@ def get_cif_from_structure(structuredata):
 def get_valid_dict(dict_node, schema):
     """Validate dictionary against schema and return Dict instance."""
     return Dict(dict=schema(dict_node.get_dict()))
+
+
+def validate_dict(dict_node, port, schema):  # pylint: disable=unused-argument
+    """Validate dictionary against schema.
+
+     To be used as validator in process input ports using functools:
+
+        validator = functools.partial(validate_dict, schema=cls.parameters_schema)
+     """
+    try:
+        schema(dict_node.get_dict())
+    except (Invalid, MultipleInvalid) as exc:
+        return str(exc)
+
+    return None

--- a/aiida_lsmo/workchains/isotherm.py
+++ b/aiida_lsmo/workchains/isotherm.py
@@ -11,7 +11,7 @@ from aiida.engine import calcfunction
 from aiida.engine import WorkChain, ToContext, append_, while_, if_
 from aiida_lsmo.utils import check_resize_unit_cell, dict_merge, validate_dict
 from aiida_lsmo.utils.isotherm_molecules_schema import ISOTHERM_MOLECULES_SCHEMA
-from .parameters_schemas import FF_PARAMETERS_VALIDATOR, Required, Any, Optional
+from .parameters_schemas import FF_PARAMETERS_VALIDATOR, Required, Optional, NUMBER
 # import sub-workchains
 RaspaBaseWorkChain = WorkflowFactory('raspa.base')  # pylint: disable=invalid-name
 
@@ -22,9 +22,6 @@ FFBuilder = CalculationFactory('lsmo.ff_builder')  # pylint: disable=invalid-nam
 # import aiida data
 CifData = DataFactory('cif')  # pylint: disable=invalid-name
 ZeoppParameters = DataFactory('zeopp.parameters')  # pylint: disable=invalid-name
-
-# Schema for isotherm parameters, including default values
-NUMBER = Any(int, float)
 
 
 # calcfunctions (in order of appearence)

--- a/aiida_lsmo/workchains/isotherm.py
+++ b/aiida_lsmo/workchains/isotherm.py
@@ -11,7 +11,7 @@ from aiida.engine import calcfunction
 from aiida.engine import WorkChain, ToContext, append_, while_, if_
 from aiida_lsmo.utils import check_resize_unit_cell, dict_merge, validate_dict
 from aiida_lsmo.utils.isotherm_molecules_schema import ISOTHERM_MOLECULES_SCHEMA
-from .parameters_schemas import FF_PARAMETERS_VALIDATOR, Required, Any
+from .parameters_schemas import FF_PARAMETERS_VALIDATOR, Required, Any, Optional
 # import sub-workchains
 RaspaBaseWorkChain = WorkflowFactory('raspa.base')  # pylint: disable=invalid-name
 
@@ -208,8 +208,8 @@ class IsothermWorkChain(WorkChain):
             NUMBER,
         Required('temperature', default=300, description='Temperature of the simulation.'):
             NUMBER,
-        'temperature_list':
-            list,  # To be used by IsothermMultiTempWorkChain.
+        Optional('temperature_list', description='To be used by IsothermMultiTempWorkChain.'):
+            list,
         Required('pressure_min', default=0.001, description='Lower pressure to sample (bar).'):
             NUMBER,
         Required('pressure_max', default=10, description='Upper pressure to sample (bar).'):
@@ -220,8 +220,9 @@ class IsothermWorkChain(WorkChain):
                  default=0.1,
                  description='Precision in the sampling of the isotherm: 0.1 ok, 0.05 for high resolution.'):
             NUMBER,
-        'pressure_list':
-            list,  # Pressure list for the isotherm (bar): if given it will skip to guess it.
+        Optional('pressure_list',
+                 description='Pressure list for the isotherm (bar): if given it will skip to guess it.'):
+            list,
     })
     parameters_info = parameters_schema.schema  # shorthand for printing
 

--- a/aiida_lsmo/workchains/isotherm.py
+++ b/aiida_lsmo/workchains/isotherm.py
@@ -2,6 +2,7 @@
 """Isotherm workchain"""
 
 import os
+import functools
 import ruamel.yaml as yaml
 from voluptuous import Required, Any
 
@@ -9,7 +10,7 @@ from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
 from aiida.orm import Dict, Str, List, SinglefileData
 from aiida.engine import calcfunction
 from aiida.engine import WorkChain, ToContext, append_, while_, if_
-from aiida_lsmo.utils import check_resize_unit_cell, dict_merge, get_valid_dict
+from aiida_lsmo.utils import check_resize_unit_cell, dict_merge, get_valid_dict, validate_dict
 from aiida_lsmo.utils.isotherm_molecules_schema import ISOTHERM_MOLECULES_SCHEMA
 from .parameters_schemas import FF_PARAMETERS_VALIDATOR
 # import sub-workchains
@@ -222,7 +223,7 @@ class IsothermWorkChain(WorkChain):
 
         spec.input('parameters',
                    valid_type=Dict,
-                   validator=lambda dict_node, port: cls.parameters_schema(dict_node.get_dict()),
+                   validator=functools.partial(validate_dict, schema=cls.parameters_schema),
                    help='Parameters for the Isotherm workchain (see workchain.schema for default values).')
 
         spec.input('geometric',

--- a/aiida_lsmo/workchains/isotherm_calc_pe.py
+++ b/aiida_lsmo/workchains/isotherm_calc_pe.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 """IsothermCalcPE work chain."""
+import functools
+from voluptuous import Required
 
 from aiida.plugins import DataFactory, WorkflowFactory
 from aiida.orm import Dict, Str
 from aiida.engine import WorkChain
-from aiida_lsmo.utils import dict_merge
+from aiida_lsmo.utils import dict_merge, validate_dict
 from aiida_lsmo.calcfunctions import PE_PARAMETERS_DEFAULT, calc_co2_parasitic_energy
+
+from .parameters_schemas import FF_PARAMETERS_VALIDATOR, NUMBER
 
 # import sub-workchains
 IsothermWorkChain = WorkflowFactory('lsmo.isotherm')  #pylint: disable=invalid-name
@@ -13,30 +17,29 @@ IsothermWorkChain = WorkflowFactory('lsmo.isotherm')  #pylint: disable=invalid-n
 # import aiida data
 CifData = DataFactory('cif')  #pylint: disable=invalid-name
 
-ISOTHERM_PARAMETERS_DEFAULT = {  # Parameters used in 10.1021/acscentsci.9b00619
-    'ff_framework': 'UFF',  # valid_type=Str, help='Forcefield of the structure.'
-    'ff_shifted': True,  # shift or truncate at cutoff
-    'ff_tail_corrections': False,  # apply tail corrections
-    'ff_mixing_rule': 'Lorentz-Berthelot',  # str, Mixing rule for the forcefield
-    'ff_separate_interactions': False,  # bool, if true use only ff_framework for framework-molecule interactions
-    'ff_cutoff': 12.0,  # valid_type=Float, help='CutOff truncation for the VdW interactions (Angstrom)'
-    'temperature': 300,  # valid_type=Float, help='Temperature of the simulation'
-    'zeopp_volpo_samples': 1e5,  # valid_type=Int,help='Number of samples for VOLPO calculation (per UC volume)'
-    'zeopp_block_samples': 100,  # valid_type=Int, help='Number of samples for BLOCK calculation (per A^3)'
-    'raspa_minKh': 1e-10,
-    'raspa_verbosity': 10,  # valid_type=Int,help='Print stats every: number of cycles / raspa_verbosity'
-    'raspa_widom_cycles': 1e5,  # valid_type=Int, help='Number of widom cycles'
-    'raspa_gcmc_init_cycles': 1e3,  # valid_type=Int, help='Number of GCMC initialization cycles'
-    'raspa_gcmc_prod_cycles': 1e4,  # valid_type=Int, help='Number of GCMC production cycles'
-    'pressure_precision': 0.1,
-    'pressure_maxstep': 5,  # valid_type=Float, help='Max distance between pressure points (bar)'
-    'pressure_min': 0.001,  # valid_type=Float, help='Lower pressure to sample (bar)'
-    'pressure_max': 30
-}
-
 
 class IsothermCalcPEWorkChain(WorkChain):
     """ Compute CO2 parassitic energy (PE) after running IsothermWorkChain for CO2 and N2 at 300K."""
+
+    parameters_schema = FF_PARAMETERS_VALIDATOR.extend({
+        Required('zeopp_probe_scaling', default=1.0): NUMBER,  # scaling probe's diameter: molecular_rad * scaling
+        Required('zeopp_volpo_samples', default=int(1e5)):
+            int,  # Number of samples for VOLPO calculation (per UC volume).
+        Required('zeopp_block_samples', default=int(100)): int,  # Number of samples for BLOCK calculation (per A^3).
+        Required('raspa_verbosity', default=10): int,  # Print stats every: number of cycles / raspa_verbosity.
+        Required('raspa_widom_cycles', default=int(1e5)): int,  # Number of Widom cycles.
+        Required('raspa_gcmc_init_cycles', default=int(1e3)): int,  # Number of GCMC initialization cycles.
+        Required('raspa_gcmc_prod_cycles', default=int(1e4)): int,  # Number of GCMC production cycles.
+        Required('raspa_minKh', default=1e-10):
+            NUMBER,  # If Henry coefficient < raspa_minKh do not run the isotherm (mol/kg/Pa).
+        Required('temperature', default=300): NUMBER,  # Temperature of the simulation.
+        Required('pressure_min', default=0.001): NUMBER,  # Lower pressure to sample (bar).
+        Required('pressure_max', default=30): NUMBER,  # Upper pressure to sample (bar).
+        Required('pressure_maxstep', default=5.0): NUMBER,  # (float) Max distance between pressure points (bar).
+        Required('pressure_precision', default=0.1):
+            NUMBER,  # (float) Precision in the sampling of the isotherm: 0.1 ok, 0.05 for high resolution.
+    })
+    parameters_info = parameters_schema.schema  # shorthand for printing
 
     @classmethod
     def define(cls, spec):
@@ -45,7 +48,8 @@ class IsothermCalcPEWorkChain(WorkChain):
         spec.expose_inputs(IsothermWorkChain, exclude=['molecule', 'parameters'])
         spec.input('parameters',
                    valid_type=Dict,
-                   default=lambda: Dict(dict=ISOTHERM_PARAMETERS_DEFAULT),
+                   default=lambda: Dict(dict=cls.parameters_schema({})),
+                   validator=functools.partial(validate_dict, schema=cls.parameters_schema),
                    help='Parameters for Isotherm work chain')
 
         spec.input('pe_parameters',

--- a/aiida_lsmo/workchains/isotherm_calc_pe.py
+++ b/aiida_lsmo/workchains/isotherm_calc_pe.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """IsothermCalcPE work chain."""
 import functools
-from voluptuous import Required
 
 from aiida.plugins import DataFactory, WorkflowFactory
 from aiida.orm import Dict, Str
@@ -9,7 +8,7 @@ from aiida.engine import WorkChain
 from aiida_lsmo.utils import dict_merge, validate_dict
 from aiida_lsmo.calcfunctions import PE_PARAMETERS_DEFAULT, calc_co2_parasitic_energy
 
-from .parameters_schemas import FF_PARAMETERS_VALIDATOR, NUMBER
+from .parameters_schemas import FF_PARAMETERS_VALIDATOR, NUMBER, Required
 
 # import sub-workchains
 IsothermWorkChain = WorkflowFactory('lsmo.isotherm')  #pylint: disable=invalid-name
@@ -22,22 +21,38 @@ class IsothermCalcPEWorkChain(WorkChain):
     """ Compute CO2 parassitic energy (PE) after running IsothermWorkChain for CO2 and N2 at 300K."""
 
     parameters_schema = FF_PARAMETERS_VALIDATOR.extend({
-        Required('zeopp_probe_scaling', default=1.0): NUMBER,  # scaling probe's diameter: molecular_rad * scaling
+        Required('zeopp_probe_scaling', default=1.0, description="scaling probe's diameter: molecular_rad * scaling"):
+            NUMBER,
         Required('zeopp_volpo_samples', default=int(1e5)):
             int,  # Number of samples for VOLPO calculation (per UC volume).
-        Required('zeopp_block_samples', default=int(100)): int,  # Number of samples for BLOCK calculation (per A^3).
-        Required('raspa_verbosity', default=10): int,  # Print stats every: number of cycles / raspa_verbosity.
-        Required('raspa_widom_cycles', default=int(1e5)): int,  # Number of Widom cycles.
-        Required('raspa_gcmc_init_cycles', default=int(1e3)): int,  # Number of GCMC initialization cycles.
-        Required('raspa_gcmc_prod_cycles', default=int(1e4)): int,  # Number of GCMC production cycles.
-        Required('raspa_minKh', default=1e-10):
-            NUMBER,  # If Henry coefficient < raspa_minKh do not run the isotherm (mol/kg/Pa).
-        Required('temperature', default=300): NUMBER,  # Temperature of the simulation.
-        Required('pressure_min', default=0.001): NUMBER,  # Lower pressure to sample (bar).
-        Required('pressure_max', default=30): NUMBER,  # Upper pressure to sample (bar).
-        Required('pressure_maxstep', default=5.0): NUMBER,  # (float) Max distance between pressure points (bar).
-        Required('pressure_precision', default=0.1):
-            NUMBER,  # (float) Precision in the sampling of the isotherm: 0.1 ok, 0.05 for high resolution.
+        Required('zeopp_block_samples',
+                 default=int(100),
+                 description='Number of samples for BLOCK calculation (per A^3).'):
+            int,
+        Required('raspa_verbosity', default=10, description='Print stats every: number of cycles / raspa_verbosity.'):
+            int,
+        Required('raspa_widom_cycles', default=int(1e5), description='Number of Widom cycles.'):
+            int,
+        Required('raspa_gcmc_init_cycles', default=int(1e3), description='Number of GCMC initialization cycles.'):
+            int,
+        Required('raspa_gcmc_prod_cycles', default=int(1e4), description='Number of GCMC production cycles.'):
+            int,
+        Required('raspa_minKh',
+                 default=1e-10,
+                 description='If Henry coefficient < raspa_minKh do not run the isotherm (mol/kg/Pa).'):
+            NUMBER,
+        Required('temperature', default=300, description='Temperature of the simulation.'):
+            NUMBER,
+        Required('pressure_min', default=0.001, description='Lower pressure to sample (bar).'):
+            NUMBER,
+        Required('pressure_max', default=30, description='Upper pressure to sample (bar).'):
+            NUMBER,
+        Required('pressure_maxstep', default=5.0, description='(float) Max distance between pressure points (bar).'):
+            NUMBER,
+        Required('pressure_precision',
+                 default=0.1,
+                 description='Precision in the sampling of the isotherm: 0.1 ok, 0.05 for high resolution.'):
+            NUMBER,
     })
     parameters_info = parameters_schema.schema  # shorthand for printing
 

--- a/aiida_lsmo/workchains/isotherm_inflection.py
+++ b/aiida_lsmo/workchains/isotherm_inflection.py
@@ -2,7 +2,6 @@
 """A work chain."""
 import functools
 import numpy as np
-from voluptuous import Required
 
 from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
 from aiida.orm import Dict, Str, List
@@ -12,7 +11,7 @@ from aiida_lsmo.utils import check_resize_unit_cell, dict_merge
 
 from .isotherm import (get_molecule_dict, get_atomic_radii, get_ff_parameters, get_zeopp_parameters, validate_dict,
                        get_geometric_dict)
-from .parameters_schemas import FF_PARAMETERS_VALIDATOR, NUMBER
+from .parameters_schemas import FF_PARAMETERS_VALIDATOR, NUMBER, Required
 
 RaspaBaseWorkChain = WorkflowFactory('raspa.base')  # pylint: disable=invalid-name
 ZeoppCalculation = CalculationFactory('zeopp.network')  # pylint: disable=invalid-name
@@ -117,21 +116,40 @@ class IsothermInflectionWorkChain(WorkChain):
     """
 
     parameters_schema = FF_PARAMETERS_VALIDATOR.extend({
-        Required('zeopp_probe_scaling', default=1.0): NUMBER,  # scaling probe's diameter: molecular_rad * scaling
-        Required('zeopp_volpo_samples', default=int(1e5)):
-            int,  # Number of samples for VOLPO calculation (per UC volume).
-        Required('zeopp_block_samples', default=int(100)): int,  # Number of samples for BLOCK calculation (per A^3).
-        Required('raspa_verbosity', default=10): int,  # Print stats every: number of cycles / raspa_verbosity.
-        Required('raspa_widom_cycles', default=int(1e5)): int,  # Number of Widom cycles.
-        Required('raspa_gcmc_init_cycles', default=int(1e3)): int,  # Number of GCMC initialization cycles.
-        Required('raspa_gcmc_prod_cycles', default=int(1e4)): int,  # Number of GCMC production cycles.
-        Required('temperature', default=300): NUMBER,  # Temperature of the simulation.
-        Required('pressure_min', default=0.001): NUMBER,  # Lower pressure to sample (bar).
-        Required('pressure_max', default=10): NUMBER,  # Upper pressure to sample (bar).
-        'pressure_list': list,  # Pressure list for the isotherm (bar): if given it will skip to guess it.
-        Required('pressure_num', default=20): int,  # Number of pressure points considered, eqispaced in a log plot
-        Required('box_length'): NUMBER,  # length of simulation box for simulation without framework
+        Required('zeopp_probe_scaling', default=1.0, description="scaling probe's diameter: molecular_rad * scaling"):
+            NUMBER,
+        Required('zeopp_volpo_samples',
+                 default=int(1e5),
+                 description='Number of samples for VOLPO calculation (per UC volume).'):
+            int,
+        Required('zeopp_block_samples',
+                 default=int(100),
+                 description='Number of samples for BLOCK calculation (per A^3).'):
+            int,
+        Required('raspa_verbosity', default=10, description='Print stats every: number of cycles / raspa_verbosity.'):
+            int,
+        Required('raspa_widom_cycles', default=int(1e5), description='Number of Widom cycles.'):
+            int,
+        Required('raspa_gcmc_init_cycles', default=int(1e3), description='Number of GCMC initialization cycles.'):
+            int,
+        Required('raspa_gcmc_prod_cycles', default=int(1e4), description='Number of GCMC production cycles.'):
+            int,
+        Required('temperature', default=300, description='Temperature of the simulation.'):
+            NUMBER,
+        Required('pressure_min', default=0.001, description='Lower pressure to sample (bar).'):
+            NUMBER,  # TODO: MIN selected from the henry coefficient!  # pylint: disable=fixme
+        Required('pressure_max', default=1.0, description='Upper pressure to sample (bar).'):
+            NUMBER,
+        'pressure_list':
+            list,  # Pressure list for the isotherm (bar): if given it will skip to guess it.
+        Required('pressure_num',
+                 default=20,
+                 description='Number of pressure points considered, eqispaced in a log plot'):
+            int,
+        Required('box_length', description='length of simulation box for simulation without framework'):
+            NUMBER,
     })
+
     parameters_info = parameters_schema.schema  # shorthand for printing
 
     @classmethod

--- a/aiida_lsmo/workchains/isotherm_inflection.py
+++ b/aiida_lsmo/workchains/isotherm_inflection.py
@@ -2,14 +2,16 @@
 """A work chain."""
 
 import numpy as np
+from voluptuous import Required
 
 from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
 from aiida.orm import Dict, Str, List
 from aiida.engine import calcfunction
 from aiida.engine import WorkChain, ToContext, if_
-from aiida_lsmo.utils import check_resize_unit_cell, aiida_dict_merge, dict_merge
+from aiida_lsmo.utils import check_resize_unit_cell, dict_merge
 
-from .isotherm import get_molecule_dict, get_atomic_radii, get_ff_parameters, get_zeopp_parameters, get_geometric_dict
+from .isotherm import (get_molecule_dict, get_atomic_radii, get_ff_parameters, get_zeopp_parameters, get_geometric_dict,
+                       BASIC_PARAMETERS_SCHEMA)
 
 RaspaBaseWorkChain = WorkflowFactory('raspa.base')  # pylint: disable=invalid-name
 ZeoppCalculation = CalculationFactory('zeopp.network')  # pylint: disable=invalid-name
@@ -17,26 +19,9 @@ FFBuilder = CalculationFactory('lsmo.ff_builder')  # pylint: disable=invalid-nam
 CifData = DataFactory('cif')  # pylint: disable=invalid-name
 ZeoppParameters = DataFactory('zeopp.parameters')  # pylint: disable=invalid-name
 
-PARAMETERS_DEFAULT = {
-    'ff_framework': 'UFF',  # (str) Forcefield of the structure.
-    'ff_separate_interactions': False,  # (bool) Use "separate_interactions" in the FF builder.
-    'ff_mixing_rule': 'Lorentz-Berthelot',  # (string) Choose 'Lorentz-Berthelot' or 'Jorgensen'.
-    'ff_tail_corrections': True,  # (bool) Apply tail corrections.
-    'ff_shifted': False,  # (bool) Shift or truncate the potential at cutoff.
-    'ff_cutoff': 12.0,  # (float) CutOff truncation for the VdW interactions (Angstrom).
-    'temperature': 300,  # (float) Temperature of the simulation.
-    'zeopp_probe_scaling': 1.0,  # float, scaling probe's diameter: use 0.0 for skipping block calc
-    'zeopp_volpo_samples': int(1e5),  # (int) Number of samples for VOLPO calculation (per UC volume).
-    'zeopp_block_samples': int(100),  # (int) Number of samples for BLOCK calculation (per A^3).
-    'raspa_verbosity': 10,  # (int) Print stats every: number of cycles / raspa_verbosity.
-    'raspa_widom_cycles': int(1e5),  # (int) Number of Widom cycles.
-    'raspa_gcmc_init_cycles': int(1e3),  # (int) Number of GCMC initialization cycles.
-    'raspa_gcmc_prod_cycles': int(1e4),  # (int) Number of GCMC production cycles.
-    'pressure_min': 0.001,  # (float) Min pressure in P/P0 TODO: MIN selected from the henry coefficient!
-    'pressure_max': 1.0,  # (float) Max pressure in P/P0
-    'pressure_num': 20,  # (int) Number of pressure points considered, eqispaced in a log plot
-    'pressure_list': None,  # (list) Pressure list in P/P0. If 'None' pressure points are computed from min/max/num.
-}
+INFLECTION_PARAMETERS_SCHEMA = BASIC_PARAMETERS_SCHEMA.extend({
+    Required('pressure_num', default=20): int,  # Number of pressure points considered, eqispaced in a log plot
+})
 
 NAVO = 6.022E+23  # molec/mol
 A3TOL = 1E-27  # L/A3
@@ -44,11 +29,18 @@ A3TOL = 1E-27  # L/A3
 
 # calcfunctions (in order of appearence)
 @calcfunction
+def get_inflection_parameters(parameters):
+    """Get inflection parameters from user input (and validate them)."""
+    validated = INFLECTION_PARAMETERS_SCHEMA(parameters.get_dict())
+    return Dict(dict=validated)
+
+
+@calcfunction
 def get_pressure_points(molecule_dict, isotparam):
     """Multiply p/p0 with p0 to have pressure points in bar if pressure_list!=None,
     or choose them based on pressure_min/max/num, to be equispaced in a Log plot.
     """
-    if isotparam['pressure_list']:
+    if 'pressure_list' in isotparam:
         pressure_points = [x * molecule_dict['pressure_zero'] for x in isotparam['pressure_list']]
     else:  # pressure_list==None
         exp_min = np.log10(isotparam['pressure_min'] * molecule_dict['pressure_zero'])
@@ -134,6 +126,8 @@ class IsothermInflectionWorkChain(WorkChain):
     This workchain is useful to spot adsorption hysteresis.
     """
 
+    parameters_schema = INFLECTION_PARAMETERS_SCHEMA.schema
+
     @classmethod
     def define(cls, spec):
         super().define(spec)
@@ -151,7 +145,7 @@ class IsothermInflectionWorkChain(WorkChain):
 
         spec.input('parameters',
                    valid_type=Dict,
-                   help='Parameters for the Isotherm workchain: will be merged with IsothermParameters_defaults.')
+                   help='Parameters for the Isotherm workchain (see workchain.schema for default values).')
 
         spec.outline(
             cls.setup,
@@ -180,7 +174,7 @@ class IsothermInflectionWorkChain(WorkChain):
             self.ctx.molecule = self.inputs.molecule
 
         # Get the parameters Dict, merging defaults with user settings
-        self.ctx.parameters = aiida_dict_merge(Dict(dict=PARAMETERS_DEFAULT), self.inputs.parameters)
+        self.ctx.parameters = get_inflection_parameters(self.inputs.parameters)
 
         # Get integer temperature in context for easy reports
         self.ctx.temperature = int(round(self.ctx.parameters['temperature']))

--- a/aiida_lsmo/workchains/isotherm_inflection.py
+++ b/aiida_lsmo/workchains/isotherm_inflection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """A work chain."""
-
+import functools
 import numpy as np
 from voluptuous import Required
 
@@ -10,7 +10,8 @@ from aiida.engine import calcfunction
 from aiida.engine import WorkChain, ToContext, if_
 from aiida_lsmo.utils import check_resize_unit_cell, dict_merge, get_valid_dict
 
-from .isotherm import (get_molecule_dict, get_atomic_radii, get_ff_parameters, get_zeopp_parameters, get_geometric_dict)
+from .isotherm import (get_molecule_dict, get_atomic_radii, get_ff_parameters, get_zeopp_parameters, validate_dict,
+                       get_geometric_dict)
 from .parameters_schemas import FF_PARAMETERS_VALIDATOR, NUMBER
 
 RaspaBaseWorkChain = WorkflowFactory('raspa.base')  # pylint: disable=invalid-name
@@ -149,7 +150,7 @@ class IsothermInflectionWorkChain(WorkChain):
 
         spec.input('parameters',
                    valid_type=Dict,
-                   validator=lambda dict_node, port: cls.parameters_schema(dict_node.get_dict()),
+                   validator=functools.partial(validate_dict, schema=cls.parameters_schema),
                    help='Parameters for the Isotherm workchain (see workchain.schema for default values).')
 
         spec.outline(

--- a/aiida_lsmo/workchains/isotherm_inflection.py
+++ b/aiida_lsmo/workchains/isotherm_inflection.py
@@ -11,7 +11,7 @@ from aiida_lsmo.utils import check_resize_unit_cell, dict_merge
 
 from .isotherm import (get_molecule_dict, get_atomic_radii, get_ff_parameters, get_zeopp_parameters, validate_dict,
                        get_geometric_dict)
-from .parameters_schemas import FF_PARAMETERS_VALIDATOR, NUMBER, Required
+from .parameters_schemas import FF_PARAMETERS_VALIDATOR, NUMBER, Required, Optional
 
 RaspaBaseWorkChain = WorkflowFactory('raspa.base')  # pylint: disable=invalid-name
 ZeoppCalculation = CalculationFactory('zeopp.network')  # pylint: disable=invalid-name
@@ -140,8 +140,9 @@ class IsothermInflectionWorkChain(WorkChain):
             NUMBER,  # TODO: MIN selected from the henry coefficient!  # pylint: disable=fixme
         Required('pressure_max', default=1.0, description='Upper pressure to sample (bar).'):
             NUMBER,
-        'pressure_list':
-            list,  # Pressure list for the isotherm (bar): if given it will skip to guess it.
+        Optional('pressure_list',
+                 description='Pressure list for the isotherm (bar): if given it will skip to guess it.'):
+            list,
         Required('pressure_num',
                  default=20,
                  description='Number of pressure points considered, eqispaced in a log plot'):

--- a/aiida_lsmo/workchains/isotherm_multi_temp.py
+++ b/aiida_lsmo/workchains/isotherm_multi_temp.py
@@ -15,7 +15,7 @@ def get_parameters_singletemp(i, parameters):
     """Get input Dict for a single isotherm calculation."""
     parameters_singletemp = parameters.get_dict()
     parameters_singletemp['temperature'] = parameters_singletemp['temperature_list'][i]
-    parameters_singletemp['temperature_list'] = None
+    parameters_singletemp.pop('temperature_list', None)
     return Dict(dict=parameters_singletemp)
 
 

--- a/aiida_lsmo/workchains/isotherm_multi_temp.py
+++ b/aiida_lsmo/workchains/isotherm_multi_temp.py
@@ -15,7 +15,7 @@ def get_parameters_singletemp(i, parameters):
     """Get input Dict for a single isotherm calculation."""
     parameters_singletemp = parameters.get_dict()
     parameters_singletemp['temperature'] = parameters_singletemp['temperature_list'][i]
-    parameters_singletemp.pop('temperature_list', None)
+    del parameters_singletemp['temperature_list']
     return Dict(dict=parameters_singletemp)
 
 

--- a/aiida_lsmo/workchains/multicomp_ads_des.py
+++ b/aiida_lsmo/workchains/multicomp_ads_des.py
@@ -3,7 +3,6 @@
 import os
 import functools
 import ruamel.yaml as yaml
-from voluptuous import Required
 
 # AiiDA modules
 from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
@@ -12,7 +11,7 @@ from aiida.engine import calcfunction
 from aiida.engine import WorkChain, if_
 from aiida_lsmo.utils import check_resize_unit_cell, validate_dict
 
-from .parameters_schemas import FF_PARAMETERS_VALIDATOR, NUMBER
+from .parameters_schemas import FF_PARAMETERS_VALIDATOR, NUMBER, Required
 
 RaspaBaseWorkChain = WorkflowFactory('raspa.base')  #pylint: disable=invalid-name
 
@@ -148,12 +147,20 @@ class MulticompAdsDesWorkChain(WorkChain):
     for a mixture of componentes and at specific temperature/pressure conditions.
     """
     parameters_schema = FF_PARAMETERS_VALIDATOR.extend({
-        Required('zeopp_probe_scaling', default=1.0): NUMBER,  # scaling probe's diameter: molecular_rad * scaling
-        Required('zeopp_block_samples', default=int(1000)): int,  # Number of samples for BLOCK calculation (per A^3).
-        Required('raspa_verbosity', default=10): int,  # Print stats every: number of cycles / raspa_verbosity.
-        Required('raspa_gcmc_init_cycles', default=int(1e3)): int,  # Number of GCMC initialization cycles.
-        Required('raspa_gcmc_prod_cycles', default=int(1e4)): int,  # Number of GCMC production cycles.
-        Required('raspa_widom_cycles', default=int(1e5)): int,  # Number of GCMC production cycles.
+        Required('zeopp_probe_scaling', default=1.0, description="scaling probe's diameter: molecular_rad * scaling"):
+            NUMBER,
+        Required('zeopp_block_samples',
+                 default=int(1000),
+                 description='Number of samples for BLOCK calculation (per A^3).'):
+            int,
+        Required('raspa_verbosity', default=10, description='Print stats every: number of cycles / raspa_verbosity.'):
+            int,
+        Required('raspa_gcmc_init_cycles', default=int(1e3), description='Number of GCMC initialization cycles.'):
+            int,
+        Required('raspa_gcmc_prod_cycles', default=int(1e4), description='Number of GCMC production cycles.'):
+            int,
+        Required('raspa_widom_cycles', default=int(1e5), description='Number of GCMC production cycles.'):
+            int,
     })
     parameters_info = parameters_schema.schema  # shorthand for printing
 

--- a/aiida_lsmo/workchains/multicomp_gcmc.py
+++ b/aiida_lsmo/workchains/multicomp_gcmc.py
@@ -2,13 +2,16 @@
 """A work chain."""
 import os
 import ruamel.yaml as yaml
+from voluptuous import Required
 
 # AiiDA modules
 from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
 from aiida.orm import Dict, SinglefileData
 from aiida.engine import calcfunction
 from aiida.engine import WorkChain, if_
-from aiida_lsmo.utils import aiida_dict_merge, check_resize_unit_cell
+from aiida_lsmo.utils import check_resize_unit_cell, get_valid_dict
+
+from .parameters_schemas import FF_PARAMETERS_VALIDATOR, NUMBER
 
 RaspaBaseWorkChain = WorkflowFactory('raspa.base')  #pylint: disable=invalid-name
 
@@ -19,21 +22,8 @@ ZeoppParameters = DataFactory('zeopp.parameters')  #pylint: disable=invalid-name
 ZeoppCalculation = CalculationFactory('zeopp.network')  #pylint: disable=invalid-name
 FFBuilder = CalculationFactory('lsmo.ff_builder')  # pylint: disable=invalid-name
 
-PARAMETERS_DEFAULT = {
-    'ff_framework': 'UFF',  # str, Forcefield of the structure (used also as a definition of ff.rad for zeopp)
-    'ff_shifted': False,  # bool, Shift or truncate at cutoff
-    'ff_tail_corrections': True,  # bool, Apply tail corrections
-    'ff_mixing_rule': 'Lorentz-Berthelot',  # str, Mixing rule for the forcefield
-    'ff_separate_interactions': False,  # bool, if true use only ff_framework for framework-molecule interactions
-    'ff_cutoff': 12.0,  # float, CutOff truncation for the VdW interactions (Angstrom)
-    'zeopp_probe_scaling': 1.0,  # float, scaling probe's diameter: use 0.0 for skipping block calc
-    'zeopp_block_samples': int(1000),  # int, Number of samples for BLOCK calculation (per A^3)
-    'raspa_verbosity': 10,  # int, Print stats every: number of cycles / raspa_verbosity
-    'raspa_gcmc_init_cycles': int(1e5),  # int, Number of GCMC initialization cycles
-    'raspa_gcmc_prod_cycles': int(1e5),  # int, Number of GCMC production cycles
-}
 
-
+# CalcFunctions in order of use
 @calcfunction
 def get_components_dict(conditions, parameters):
     """Construct components dict, like:
@@ -149,6 +139,14 @@ class MulticompGcmcWorkChain(WorkChain):
     for a mixture of componentes and at specific temperature/pressure conditions.
     """
 
+    parameters_schema = FF_PARAMETERS_VALIDATOR.extend({
+        Required('zeopp_probe_scaling', default=1.0): NUMBER,  # scaling probe's diameter: molecular_rad * scaling
+        Required('zeopp_block_samples', default=int(1e3)): int,  # Number of samples for BLOCK calculation (per A^3).
+        Required('raspa_gcmc_init_cycles', default=int(1e5)): int,  # Number of GCMC initialization cycles.
+        Required('raspa_gcmc_prod_cycles', default=int(1e5)): int,  # Number of GCMC production cycles.
+    })
+    parameters_info = parameters_schema.schema  # shorthand for printing
+
     @classmethod
     def define(cls, spec):
         super(MulticompGcmcWorkChain, cls).define(spec)
@@ -161,6 +159,7 @@ class MulticompGcmcWorkChain(WorkChain):
                    help='Composition of the mixture, list of temperature and pressure conditions.')
         spec.input('parameters',
                    valid_type=Dict,
+                   validator=lambda dict_node, port: cls.parameters_schema(dict_node.get_dict()),
                    help='Main parameters and settings for the calculations, to overwrite PARAMETERS_DEFAULT.')
         spec.outline(
             cls.setup,
@@ -180,7 +179,7 @@ class MulticompGcmcWorkChain(WorkChain):
     def setup(self):
         """Initialize parameters"""
         self.ctx.sim_in_box = 'structure' not in self.inputs.keys()
-        self.ctx.parameters = aiida_dict_merge(Dict(dict=PARAMETERS_DEFAULT), self.inputs.parameters)
+        self.ctx.parameters = get_valid_dict(dict_node=self.inputs.parameters, schema=self.parameters_schema)
         self.ctx.components = get_components_dict(self.inputs.conditions, self.ctx.parameters)
         self.ctx.ff_params = get_ff_parameters(self.ctx.components, self.ctx.parameters)
 

--- a/aiida_lsmo/workchains/multicomp_gcmc.py
+++ b/aiida_lsmo/workchains/multicomp_gcmc.py
@@ -3,7 +3,6 @@
 import os
 import functools
 import ruamel.yaml as yaml
-from voluptuous import Required
 
 # AiiDA modules
 from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
@@ -12,7 +11,7 @@ from aiida.engine import calcfunction
 from aiida.engine import WorkChain, if_
 from aiida_lsmo.utils import check_resize_unit_cell, validate_dict
 
-from .parameters_schemas import FF_PARAMETERS_VALIDATOR, NUMBER
+from .parameters_schemas import FF_PARAMETERS_VALIDATOR, NUMBER, Required
 
 RaspaBaseWorkChain = WorkflowFactory('raspa.base')  #pylint: disable=invalid-name
 
@@ -141,11 +140,18 @@ class MulticompGcmcWorkChain(WorkChain):
     """
 
     parameters_schema = FF_PARAMETERS_VALIDATOR.extend({
-        Required('zeopp_probe_scaling', default=1.0): NUMBER,  # scaling probe's diameter: molecular_rad * scaling
-        Required('zeopp_block_samples', default=int(1e3)): int,  # Number of samples for BLOCK calculation (per A^3).
-        Required('raspa_gcmc_init_cycles', default=int(1e5)): int,  # Number of GCMC initialization cycles.
-        Required('raspa_gcmc_prod_cycles', default=int(1e5)): int,  # Number of GCMC production cycles.
-        Required('raspa_verbosity', default=10): int,  # Print stats every: number of cycles / raspa_verbosity.
+        Required('zeopp_probe_scaling', default=1.0, description="scaling probe's diameter: molecular_rad * scaling"):
+            NUMBER,
+        Required('zeopp_block_samples',
+                 default=int(1e3),
+                 description='Number of samples for BLOCK calculation (per A^3).'):
+            int,
+        Required('raspa_gcmc_init_cycles', default=int(1e5), description='Number of GCMC initialization cycles.'):
+            int,
+        Required('raspa_gcmc_prod_cycles', default=int(1e5), description='Number of GCMC production cycles.'):
+            int,
+        Required('raspa_verbosity', default=10, description='Print stats every: number of cycles / raspa_verbosity.'):
+            int,
     })
     parameters_info = parameters_schema.schema  # shorthand for printing
 

--- a/aiida_lsmo/workchains/multicomp_gcmc.py
+++ b/aiida_lsmo/workchains/multicomp_gcmc.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """A work chain."""
 import os
+import functools
 import ruamel.yaml as yaml
 from voluptuous import Required
 
@@ -9,7 +10,7 @@ from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
 from aiida.orm import Dict, SinglefileData
 from aiida.engine import calcfunction
 from aiida.engine import WorkChain, if_
-from aiida_lsmo.utils import check_resize_unit_cell, get_valid_dict
+from aiida_lsmo.utils import check_resize_unit_cell, get_valid_dict, validate_dict
 
 from .parameters_schemas import FF_PARAMETERS_VALIDATOR, NUMBER
 
@@ -159,7 +160,7 @@ class MulticompGcmcWorkChain(WorkChain):
                    help='Composition of the mixture, list of temperature and pressure conditions.')
         spec.input('parameters',
                    valid_type=Dict,
-                   validator=lambda dict_node, port: cls.parameters_schema(dict_node.get_dict()),
+                   validator=functools.partial(validate_dict, schema=cls.parameters_schema),
                    help='Main parameters and settings for the calculations, to overwrite PARAMETERS_DEFAULT.')
         spec.outline(
             cls.setup,

--- a/aiida_lsmo/workchains/parameters_schemas.py
+++ b/aiida_lsmo/workchains/parameters_schemas.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""Schemas for validating input parameters of workchains.
+
+Defines a couple of building blocks that are reused by many workchains.
+"""
+from voluptuous import Schema, Required, Any
+
+NUMBER = Any(int, float)
+
+FF_PARAMETERS_VALIDATOR = Schema({
+    Required('ff_framework', default='UFF'):
+        str,  # Forcefield of the structure  (used also as a definition of ff.rad for zeopp)
+    Required('ff_separate_interactions', default=False):
+        bool,  # if true use only ff_framework for framework-molecule interactions in the FFBuilder
+    Required('ff_mixing_rule', default='Lorentz-Berthelot'): Any('Lorentz-Berthelot', 'Jorgensen'),  # Mixing rule
+    Required('ff_tail_corrections', default=True): bool,  # Apply tail corrections.
+    Required('ff_shifted', default=False): bool,  # Shift or truncate the potential at cutoff.
+    Required('ff_cutoff', default=12.0): NUMBER,  # CutOff truncation for the VdW interactions (Angstrom).
+})

--- a/aiida_lsmo/workchains/parameters_schemas.py
+++ b/aiida_lsmo/workchains/parameters_schemas.py
@@ -3,17 +3,47 @@
 
 Defines a couple of building blocks that are reused by many workchains.
 """
-from voluptuous import Schema, Required, Any
+__all__ = ('Required', 'Optional', 'NUMBER', 'FF_PARAMETERS_VALIDATOR')
+import voluptuous
 
-NUMBER = Any(int, float)
 
-FF_PARAMETERS_VALIDATOR = Schema({
-    Required('ff_framework', default='UFF'):
-        str,  # Forcefield of the structure  (used also as a definition of ff.rad for zeopp)
-    Required('ff_separate_interactions', default=False):
-        bool,  # if true use only ff_framework for framework-molecule interactions in the FFBuilder
-    Required('ff_mixing_rule', default='Lorentz-Berthelot'): Any('Lorentz-Berthelot', 'Jorgensen'),  # Mixing rule
-    Required('ff_tail_corrections', default=True): bool,  # Apply tail corrections.
-    Required('ff_shifted', default=False): bool,  # Shift or truncate the potential at cutoff.
-    Required('ff_cutoff', default=12.0): NUMBER,  # CutOff truncation for the VdW interactions (Angstrom).
+def show_description(cls):
+    """Adds description to representation of voluptuous Marker.
+
+    This makes the description show up in the sphinx autodoc.
+    """
+
+    def __repr__(self):
+        if self.description:
+            return f'{self.__class__.__name__}({repr(self.schema)}, description={repr(self.description)})'
+        return repr(self.schema)
+
+    setattr(cls, '__repr__', __repr__)
+    return cls
+
+
+Required = show_description(voluptuous.Required)
+Optional = show_description(voluptuous.Optional)
+Any = voluptuous.Any
+Schema = voluptuous.Schema
+
+NUMBER = voluptuous.Any(int, float)
+
+FF_PARAMETERS_VALIDATOR = voluptuous.Schema({
+    Required('ff_framework',
+             default='UFF',
+             description='Forcefield of the structure  (used also as a definition of ff.rad for zeopp)'):
+        str,
+    Required('ff_separate_interactions',
+             default=False,
+             description='if true use only ff_framework for framework-molecule interactions in the FFBuilder'):
+        bool,
+    Required('ff_mixing_rule', default='Lorentz-Berthelot', description='Mixing rule'):
+        Any('Lorentz-Berthelot', 'Jorgensen'),
+    Required('ff_tail_corrections', default=True, description='Apply tail corrections.'):
+        bool,
+    Required('ff_shifted', default=False, description='Shift or truncate the potential at cutoff.'):
+        bool,
+    Required('ff_cutoff', default=12.0, description='CutOff truncation for the VdW interactions (Angstrom).'):
+        NUMBER,
 })

--- a/aiida_lsmo/workchains/sim_annealing.py
+++ b/aiida_lsmo/workchains/sim_annealing.py
@@ -2,13 +2,14 @@
 """Isotherm workchain"""
 
 import os
+import functools
 from voluptuous import Required
 import ase
 from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
 from aiida.orm import Dict, Str
 from aiida.engine import calcfunction
 from aiida.engine import WorkChain, ToContext, append_, while_
-from aiida_lsmo.utils import check_resize_unit_cell, aiida_cif_merge, get_valid_dict
+from aiida_lsmo.utils import check_resize_unit_cell, aiida_cif_merge, get_valid_dict, validate_dict
 from aiida_lsmo.calcfunctions.ff_builder_module import load_yaml
 
 from .isotherm import get_molecule_dict, get_ff_parameters
@@ -132,7 +133,7 @@ class SimAnnealingWorkChain(WorkChain):
 
         spec.input('parameters',
                    valid_type=Dict,
-                   validator=lambda dict_node, port: cls.parameters_schema(dict_node.get_dict()),
+                   validator=functools.partial(validate_dict, schema=cls.parameters_schema),
                    help='Parameters for the SimAnnealing workchain: will be merged with default ones.')
 
         spec.outline(cls.setup, while_(cls.should_run_nvt)(cls.run_raspa_nvt,), cls.run_raspa_min, cls.return_results)

--- a/aiida_lsmo/workchains/sim_annealing.py
+++ b/aiida_lsmo/workchains/sim_annealing.py
@@ -9,7 +9,7 @@ from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
 from aiida.orm import Dict, Str
 from aiida.engine import calcfunction
 from aiida.engine import WorkChain, ToContext, append_, while_
-from aiida_lsmo.utils import check_resize_unit_cell, aiida_cif_merge, get_valid_dict, validate_dict
+from aiida_lsmo.utils import check_resize_unit_cell, aiida_cif_merge, validate_dict
 from aiida_lsmo.calcfunctions.ff_builder_module import load_yaml
 
 from .isotherm import get_molecule_dict, get_ff_parameters
@@ -204,7 +204,11 @@ class SimAnnealingWorkChain(WorkChain):
             self.ctx.molecule = self.inputs.molecule
 
         # Get the parameters Dict, merging defaults with user settings
-        self.ctx.parameters = get_valid_dict(dict_node=self.inputs.parameters, schema=self.parameters_schema)
+        @calcfunction
+        def get_valid_dict(dict_node):
+            return Dict(dict=self.parameters_schema(dict_node.get_dict()))
+
+        self.ctx.parameters = get_valid_dict(self.inputs.parameters)
 
         # Initialize the input for raspa_base, which later will need only minor updates
         self.ctx.inp = self.exposed_inputs(RaspaBaseWorkChain, 'raspa_base')

--- a/aiida_lsmo/workchains/singlecomp_widom.py
+++ b/aiida_lsmo/workchains/singlecomp_widom.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
 """A work chain."""
+import functools
+from voluptuous import Required
 
 # AiiDA modules
 from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
 from aiida.orm import Str, Dict
 from aiida.engine import calcfunction
 from aiida.engine import WorkChain, if_
-from aiida_lsmo.utils import aiida_dict_merge, check_resize_unit_cell
+from aiida_lsmo.utils import get_valid_dict, check_resize_unit_cell
 
-from .isotherm import get_molecule_dict, get_ff_parameters, get_atomic_radii
+from .isotherm import get_molecule_dict, get_ff_parameters, get_atomic_radii, validate_dict
+from .parameters_schemas import FF_PARAMETERS_VALIDATOR, NUMBER
 
 RaspaBaseWorkChain = WorkflowFactory('raspa.base')  #pylint: disable=invalid-name
 
@@ -18,20 +21,6 @@ ZeoppParameters = DataFactory('zeopp.parameters')  #pylint: disable=invalid-name
 
 ZeoppCalculation = CalculationFactory('zeopp.network')  #pylint: disable=invalid-name
 FFBuilder = CalculationFactory('lsmo.ff_builder')  # pylint: disable=invalid-name
-
-PARAMETERS_DEFAULT = {  #TODO: create IsothermParameters instead of Dict # pylint: disable=fixme
-    'ff_framework': 'UFF',  # str, Forcefield of the structure (used also as a definition of ff.rad for zeopp)
-    'ff_shifted': False,  # bool, Shift or truncate at cutoff
-    'ff_tail_corrections': True,  # bool, Apply tail corrections
-    'ff_mixing_rule': 'Lorentz-Berthelot',  # str, Mixing rule for the forcefield
-    'ff_separate_interactions': False,  # bool, if true use only ff_framework for framework-molecule interactions
-    'ff_cutoff': 12.0,  # float, CutOff truncation for the VdW interactions (Angstrom)
-    'zeopp_probe_scaling': 1.0,  # float, scaling probe's diameter: use 0.0 for skipping block calc
-    'zeopp_block_samples': int(1000),  # int, Number of samples for BLOCK calculation (per A^3)
-    'raspa_verbosity': 10,  # int, Print stats every: number of cycles / raspa_verbosity
-    'raspa_widom_cycles': int(1e5),  # int, Number of widom cycles
-    'temperatures': [300, 400]
-}
 
 
 @calcfunction
@@ -78,6 +67,15 @@ def get_output_parameters(inp_parameters, **all_out_dicts):
 class SinglecompWidomWorkChain(WorkChain):
     """Computes widom insertion for a framework/box at different temperatures."""
 
+    parameters_schema = FF_PARAMETERS_VALIDATOR.extend({
+        Required('zeopp_probe_scaling', default=1.0): NUMBER,  # scaling probe's diameter: molecular_rad * scaling
+        Required('zeopp_block_samples', default=int(100)): int,  # Number of samples for BLOCK calculation (per A^3).
+        Required('raspa_verbosity', default=10): int,  # Print stats every: number of cycles / raspa_verbosity.
+        Required('raspa_widom_cycles', default=int(1e5)): int,  # Number of Widom cycles.
+        Required('temperatures', default=[300, 400]): [NUMBER],
+    })
+    parameters_info = parameters_schema.schema  # shorthand for printing
+
     @classmethod
     def define(cls, spec):
         super(SinglecompWidomWorkChain, cls).define(spec)
@@ -91,6 +89,7 @@ class SinglecompWidomWorkChain(WorkChain):
                    'Advanced: input a Dict for non-standard settings.')
         spec.input('parameters',
                    valid_type=Dict,
+                   validator=functools.partial(validate_dict, schema=cls.parameters_schema),
                    help='Main parameters and settings for the calculations, to overwrite PARAMETERS_DEFAULT.')
         spec.outline(
             cls.setup,
@@ -106,7 +105,7 @@ class SinglecompWidomWorkChain(WorkChain):
     def setup(self):
         """Initialize parameters"""
         self.ctx.sim_in_box = 'structure' not in self.inputs.keys()
-        self.ctx.parameters = aiida_dict_merge(Dict(dict=PARAMETERS_DEFAULT), self.inputs.parameters)
+        self.ctx.parameters = get_valid_dict(dict_node=self.inputs.parameters, schema=self.parameters_schema)
         if isinstance(self.inputs.molecule, Str):
             self.ctx.molecule = get_molecule_dict(self.inputs.molecule)
         elif isinstance(self.inputs.molecule, Dict):

--- a/aiida_lsmo/workchains/singlecomp_widom.py
+++ b/aiida_lsmo/workchains/singlecomp_widom.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """A work chain."""
 import functools
-from voluptuous import Required
 
 # AiiDA modules
 from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
@@ -11,7 +10,7 @@ from aiida.engine import WorkChain, if_
 from aiida_lsmo.utils import check_resize_unit_cell
 
 from .isotherm import get_molecule_dict, get_ff_parameters, get_atomic_radii, validate_dict
-from .parameters_schemas import FF_PARAMETERS_VALIDATOR, NUMBER
+from .parameters_schemas import FF_PARAMETERS_VALIDATOR, NUMBER, Required
 
 RaspaBaseWorkChain = WorkflowFactory('raspa.base')  #pylint: disable=invalid-name
 
@@ -68,10 +67,16 @@ class SinglecompWidomWorkChain(WorkChain):
     """Computes widom insertion for a framework/box at different temperatures."""
 
     parameters_schema = FF_PARAMETERS_VALIDATOR.extend({
-        Required('zeopp_probe_scaling', default=1.0): NUMBER,  # scaling probe's diameter: molecular_rad * scaling
-        Required('zeopp_block_samples', default=int(100)): int,  # Number of samples for BLOCK calculation (per A^3).
-        Required('raspa_verbosity', default=10): int,  # Print stats every: number of cycles / raspa_verbosity.
-        Required('raspa_widom_cycles', default=int(1e5)): int,  # Number of Widom cycles.
+        Required('zeopp_probe_scaling', default=1.0, description="scaling probe's diameter: molecular_rad * scaling"):
+            NUMBER,
+        Required('zeopp_block_samples',
+                 default=int(100),
+                 description='Number of samples for BLOCK calculation (per A^3).'):
+            int,
+        Required('raspa_verbosity', default=10, description='Print stats every: number of cycles / raspa_verbosity.'):
+            int,
+        Required('raspa_widom_cycles', default=int(1e5), description='Number of Widom cycles.'):
+            int,
         Required('temperatures', default=[300, 400]): [NUMBER],
     })
     parameters_info = parameters_schema.schema  # shorthand for printing

--- a/aiida_lsmo/workchains/zeopp_multistage_ddec.py
+++ b/aiida_lsmo/workchains/zeopp_multistage_ddec.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 """ZeoppMultistageDdecWorkChain work chain"""
 import functools
-from voluptuous import Schema, Required
 
 from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
 from aiida.common import AttributeDict
 from aiida.engine import WorkChain, ToContext
 from aiida_lsmo.utils import get_structure_from_cif, validate_dict
 
-from .parameters_schemas import NUMBER
+from .parameters_schemas import NUMBER, Required, Schema
 
 # import sub-workchains
 Cp2kMultistageDdecWorkChain = WorkflowFactory('lsmo.cp2k_multistage_ddec')  # pylint: disable=invalid-name
@@ -26,13 +25,19 @@ class ZeoppMultistageDdecWorkChain(WorkChain):
     """A workchain that combines: Zeopp + Cp2kMultistageWorkChain + Cp2kDdecWorkChain + Zeopp"""
 
     parameters_schema = Schema({
-        Required('ha', default='DEF'): str,  # Using high accuracy (mandatory!)
-        Required('res', default=True): bool,  # Max included, free and incl in free sphere
-        Required('sa', default=[1.86, 1.86, 100000]): [NUMBER, NUMBER, int],  # Nitrogen probe to compute surface
-        Required('vol', default=[0.0, 0.0, 1000000]): [NUMBER, NUMBER, int],  # Geometric pore volume
+        Required('ha', default='DEF', description='Using high accuracy (mandatory!)'):
+            str,
+        Required('res', default=True, description='Max included, free and incl in free sphere'):
+            bool,
+        Required('sa', default=[1.86, 1.86, 100000], description='Nitrogen probe to compute surface'): [
+            NUMBER, NUMBER, int
+        ],
+        Required('vol', default=[0.0, 0.0, 1000000], description='Geometric pore volume'): [NUMBER, NUMBER, int],
         Required('volpo', default=[1.86, 1.86, 100000]): [NUMBER, NUMBER, int],
         # Nitrogen probe to compute PO pore volume
-        Required('psd', default=[1.2, 1.2, 10000]): [NUMBER, NUMBER, int],  # Small probe to compute the pore size distr
+        Required('psd', default=[1.2, 1.2, 10000], description='Small probe to compute the pore size distr'): [
+            NUMBER, NUMBER, int
+        ],
     })
     parameters_info = parameters_schema.schema  # shorthand for printing
 

--- a/aiida_lsmo/workchains/zeopp_multistage_ddec.py
+++ b/aiida_lsmo/workchains/zeopp_multistage_ddec.py
@@ -33,8 +33,9 @@ class ZeoppMultistageDdecWorkChain(WorkChain):
             NUMBER, NUMBER, int
         ],
         Required('vol', default=[0.0, 0.0, 1000000], description='Geometric pore volume'): [NUMBER, NUMBER, int],
-        Required('volpo', default=[1.86, 1.86, 100000]): [NUMBER, NUMBER, int],
-        # Nitrogen probe to compute PO pore volume
+        Required('volpo', default=[1.86, 1.86, 100000], description='Nitrogen probe to compute PO pore volume'): [
+            NUMBER, NUMBER, int
+        ],
         Required('psd', default=[1.2, 1.2, 10000], description='Small probe to compute the pore size distr'): [
             NUMBER, NUMBER, int
         ],

--- a/aiida_lsmo/workchains/zeopp_multistage_ddec.py
+++ b/aiida_lsmo/workchains/zeopp_multistage_ddec.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 """ZeoppMultistageDdecWorkChain work chain"""
+import functools
+from voluptuous import Schema, Required
 
 from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
 from aiida.common import AttributeDict
 from aiida.engine import WorkChain, ToContext
-from aiida_lsmo.utils import get_structure_from_cif
+from aiida_lsmo.utils import get_structure_from_cif, validate_dict
+
+from .parameters_schemas import NUMBER
 
 # import sub-workchains
 Cp2kMultistageDdecWorkChain = WorkflowFactory('lsmo.cp2k_multistage_ddec')  # pylint: disable=invalid-name
@@ -17,18 +21,20 @@ ZeoppCalculation = CalculationFactory('zeopp.network')  # pylint: disable=invali
 CifData = DataFactory('cif')  # pylint: disable=invalid-name
 NetworkParameters = DataFactory('zeopp.parameters')  # pylint: disable=invalid-name
 
-ZEOPP_PARAMETERS_DEFAULT = {  #Default parameters for microporous materials
-    'ha': 'DEF',  # Using high accuracy (mandatory!)
-    'res': True,  # Max included, free and incl in free sphere
-    'sa': [1.86, 1.86, 100000],  # Nitrogen probe to compute surface
-    'vol': [0.0, 0.0, 1000000],  # Geometric pore volume
-    'volpo': [1.86, 1.86, 100000],  # Nitrogen probe to compute PO pore volume
-    'psd': [1.2, 1.2, 10000]  # Small probe to compute the pore size distr
-}
-
 
 class ZeoppMultistageDdecWorkChain(WorkChain):
     """A workchain that combines: Zeopp + Cp2kMultistageWorkChain + Cp2kDdecWorkChain + Zeopp"""
+
+    parameters_schema = Schema({
+        Required('ha', default='DEF'): str,  # Using high accuracy (mandatory!)
+        Required('res', default=True): bool,  # Max included, free and incl in free sphere
+        Required('sa', default=[1.86, 1.86, 100000]): [NUMBER, NUMBER, int],  # Nitrogen probe to compute surface
+        Required('vol', default=[0.0, 0.0, 1000000]): [NUMBER, NUMBER, int],  # Geometric pore volume
+        Required('volpo', default=[1.86, 1.86, 100000]): [NUMBER, NUMBER, int],
+        # Nitrogen probe to compute PO pore volume
+        Required('psd', default=[1.2, 1.2, 10000]): [NUMBER, NUMBER, int],  # Small probe to compute the pore size distr
+    })
+    parameters_info = parameters_schema.schema  # shorthand for printing
 
     @classmethod
     def define(cls, spec):
@@ -37,7 +43,8 @@ class ZeoppMultistageDdecWorkChain(WorkChain):
 
         spec.input('structure', valid_type=CifData, help='input structure')
         spec.expose_inputs(ZeoppCalculation, namespace='zeopp', exclude=['structure'])
-        spec.inputs['zeopp']['parameters'].default = lambda: NetworkParameters(dict=ZEOPP_PARAMETERS_DEFAULT)
+        spec.inputs['zeopp']['parameters'].default = lambda: NetworkParameters(dict=cls.parameters_schema({}))
+        spec.inputs['zeopp']['parameters'].validator = functools.partial(validate_dict, schema=cls.parameters_schema)
         spec.inputs['zeopp']['parameters'].required = False
 
         spec.expose_inputs(Cp2kMultistageDdecWorkChain, exclude=['structure'])

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,8 +71,6 @@ intersphinx_mapping = {
     'aiida_cp2k': ('https://aiida-cp2k.readthedocs.io/en/latest/', None),
 }
 
-nitpick_ignore = [('py:obj', 'module')]
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
@@ -426,4 +424,5 @@ nitpick_ignore = [
     ('py:obj', 'float'),
     ('py:obj', 'bool'),
     ('py:obj', 'Mapping'),
+    ('py:class', 'voluptuous.schema_builder.Marker'),
 ]


### PR DESCRIPTION
fixes #39

Validates `parameters` input of all WorkChains using `voluptuous` schemas (both for the keys present and for the type of their values).
Validation happens when passing the builder to the WorkChain, i.e. the workchain is not submitted if the dictionary fails validation.

The behavior of the `pressure_list` and `temperature_list` keys is modified slightly: if you don't want to provide them, simply don't set the key (instead of setting the key to `None`).

The schema is part of the API documentation:
![image](https://user-images.githubusercontent.com/1053245/100039947-a05c0a00-2e06-11eb-93d7-ac3ed41e1f2a.png)
and users can do `print(myworkchain.parameters_info)` to check which parameters the workchain needs.

Todo:
 - [ ] (optional) introduce line breaks in the docs representation to make it more readable