### PR TITLE
fix readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 build:
   image: latest
 python:
-  version: 3.6
+  version: 3.7
   pip_install: true
   extra_requirements:
   - "docs"

--- a/setup.json
+++ b/setup.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/lsmo-epfl/aiida-lsmo",
     "license": "MIT License",
     "classifiers": [
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7"
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8"
     ],
     "include_package_data": true,
     "install_requires": [


### PR DESCRIPTION
started installing numpy 1.20 release candidate, which requires python
3.7, leading the readthedocs build to fail, see https://readthedocs.org/projects/aiida-lsmo/builds/12522589/

```
  File "/tmp/easy_install-1pnmpbr9/numpy-1.20.0rc1/setup.py", line 30, in <module>

RuntimeError: Python version >= 3.7 required.
```

given that aiida-core is also following the numpy support cycle, which
will drop python 3.6 support on Jan 21 2021, we can do this here as
well.