### PR TITLE
fix initial_magnetization "zero" use case

### DIFF
--- a/aiida_lsmo/workchains/cp2k_multistage.py
+++ b/aiida_lsmo/workchains/cp2k_multistage.py
@@ -64,7 +64,7 @@ def apply_initial_magnetization(structure, protocol, oxidation_states=None):
         atoms = set_initial_conditions(atoms=atoms, initial_magnetization=protocol_dict['initial_magnetization'])
 
     cp2k_param = get_kinds_section(atoms=atoms, protocol=protocol_dict)
-    dict_merge(cp2k_param, get_multiplicity_section(atoms=atoms))
+    dict_merge(cp2k_param, get_multiplicity_section(atoms=atoms, protocol=protocol_dict))
 
     return {'structure': StructureData(ase=atoms), 'cp2k_param': Dict(dict=cp2k_param)}
 

--- a/tests/test_oxidation_state.py
+++ b/tests/test_oxidation_state.py
@@ -147,5 +147,5 @@ def test_cp2k_kinds(cu_hkust_oxidation):  # pylint: disable=redefined-outer-name
     assert len(kinds_section['FORCE_EVAL']['SUBSYS']['KIND']) == len(set(
         atoms.get_chemical_symbols())) + 1, kinds_section['FORCE_EVAL']['SUBSYS']['KIND']
 
-    multiplicity_section = get_multiplicity_section(atoms=atoms)
+    multiplicity_section = get_multiplicity_section(atoms=atoms, protocol=protocol)
     assert multiplicity_section['FORCE_EVAL']['DFT']['MULTIPLICITY'] == 8 * 1 + 1, multiplicity_section


### PR DESCRIPTION
When using initial magnetization "zero", the multiplicity of the
calculation should no longer be based on the intial magnetization.
Instead it should be 1 for even number of electrons and 2 for uneven
number of electrons.