### PR TITLE
catch exceptions when prediction oxidation states

### DIFF
--- a/aiida_lsmo/calcfunctions/oxidation_state.py
+++ b/aiida_lsmo/calcfunctions/oxidation_state.py
@@ -14,6 +14,12 @@ def compute_oxidation_states(cif):
     :param cif:  AiiDA CifData instance
     :return: AiiDA Dict node
     """
-    results_dict = OXIMACHINE_RUNNER.run_oximachine(cif.get_ase())
+    try:
+        results_dict = OXIMACHINE_RUNNER.run_oximachine(cif.get_ase())
+    except Exception:  # pylint: disable=broad-except
+        results_dict = {
+            k: [] for k in ['metal_indices', 'metal_symbols', 'prediction', 'max_probabs', 'base_predictions']
+        }
+
     results_dict['oximachine_version'] = str(OXIMACHINE_RUNNER)
     return Dict(dict=results_dict)

--- a/tests/data/CO2.cif
+++ b/tests/data/CO2.cif
@@ -1,0 +1,13 @@
+data_image0
+loop_
+  _atom_site_label
+  _atom_site_occupancy
+  _atom_site_Cartn_x
+  _atom_site_Cartn_y
+  _atom_site_Cartn_z
+  _atom_site_thermal_displace_type
+  _atom_site_B_iso_or_equiv
+  _atom_site_type_symbol
+  C1       1.0000 0.00000  0.00000  0.00000  Biso   1.000  C
+  O1       1.0000 0.00000  0.00000  1.17866  Biso   1.000  O
+  O2       1.0000 0.00000  0.00000  -1.17866  Biso   1.000  O

--- a/tests/test_oxidation_state.py
+++ b/tests/test_oxidation_state.py
@@ -13,11 +13,12 @@ from aiida_lsmo.workchains.cp2k_multistage_protocols import set_initial_conditio
 from aiida_lsmo.utils.cp2k_utils import get_kinds_section, get_multiplicity_section
 from . import DATA_DIR
 
-CIF_FILES = ['Fe-MOF-74.cif', 'Mg_MOF_74.cif', 'Cu-I-II-HKUST-1.cif']
+CIF_FILES = ['Fe-MOF-74.cif', 'Mg_MOF_74.cif', 'Cu-I-II-HKUST-1.cif', 'CO2.cif']
 OXIDATION_STATES = {
     'Fe-MOF-74.cif': [2, 2, 2, 2, 2, 2],
     'Mg_MOF_74.cif': [2, 2, 2, 2, 2, 2],
     'Cu-I-II-HKUST-1.cif': [1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2],
+    'CO2.cif': [],
 }
 
 


### PR DESCRIPTION
fixes #74 

The oximachine_runner would throw exceptions in a number of scenarios
(no metal in structure, parsing failed, featurization failed, ...).

This commit catches these exceptions and returns an empty list of
predictions in case an exception is encountered.

It also switches the `test.yaml` multistage protocol to use the
oximachine for the initial magnetization (before, it was the only
protocol using "element", which caused confusion).