### PR TITLE
fix test scripts

### DIFF
--- a/examples/test_Cp2kBindingEnergy_CO2_MOF74.py
+++ b/examples/test_Cp2kBindingEnergy_CO2_MOF74.py
@@ -93,7 +93,7 @@ def run_binding_energy_co2_mof74(cp2k_code, zn_mof74, co2_in_mof74):  # pylint: 
 def cli(cp2k_code):
     """Run example.
 
-    Example usage: $ ./test_multistage_aluminum.py --cp2k-code my-cp2k@myhost
+    Example usage: $ ./test_Cp2kBindingEnergy_CO2_MOF74.py --cp2k-code my-cp2k@myhost
     """
     run_binding_energy_co2_mof74(cp2k_code,
                                  zn_mof74=StructureData(ase=ase.io.read(DATA_DIR / 'Zn-MOF-74.cif')),

--- a/examples/test_Cp2kMultistageDdecWorkChain_H2O.py
+++ b/examples/test_Cp2kMultistageDdecWorkChain_H2O.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Test/example for the DdecMultistageDdec WorkChain."""
 
+from pathlib import Path
 import click
 import ase.build
 
@@ -9,7 +10,9 @@ from aiida.plugins import DataFactory, WorkflowFactory
 from aiida import cmdline
 from aiida import engine
 from aiida.orm import Dict, StructureData, Str, SinglefileData
-from . import DATA_DIR
+
+THIS_DIR = Path(__file__).resolve().parent
+DATA_DIR = THIS_DIR / 'data'
 
 # Workchain object
 MultistageDdecWorkChain = WorkflowFactory('lsmo.cp2k_multistage_ddec')  # pylint: disable=invalid-name

--- a/examples/test_Cp2kMultistageWorkChain_Al.py
+++ b/examples/test_Cp2kMultistageWorkChain_Al.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Run Cp2kMultistageWorkChain workchain on Aluminum."""
 
+from pathlib import Path
 import pytest
 import click
 import ase.build
@@ -10,7 +11,9 @@ from aiida.plugins import DataFactory, WorkflowFactory
 from aiida import cmdline
 from aiida import engine
 from aiida.orm import Dict, StructureData, Str, Int, SinglefileData
-from . import DATA_DIR
+
+THIS_DIR = Path(__file__).resolve().parent
+DATA_DIR = THIS_DIR / 'data'
 
 # Workchain objects
 Cp2kMultistageWorkChain = WorkflowFactory('lsmo.cp2k_multistage')
@@ -87,7 +90,7 @@ def run_multistage_al(cp2k_code, al_structuredata):  # pylint: disable=redefined
 def cli(cp2k_code):
     """Run example.
 
-    Example usage: $ ./test_multistage_aluminum.py --cp2k-code my-cp2k@myhost
+    Example usage: $ ./test_Cp2kMultistageWorkChain_Al.py --cp2k-code my-cp2k@myhost
     """
     run_multistage_al(cp2k_code, al_structuredata=StructureData(ase=ase.io.read(DATA_DIR / 'Al.cif')))
 

--- a/examples/test_IsothermInflectionWorkChain_graphite_Ar.py
+++ b/examples/test_IsothermInflectionWorkChain_graphite_Ar.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Run example IsothermInflection for Ar in Graphite."""
 
+from pathlib import Path
 import os
 import click
 import pytest
@@ -11,7 +12,8 @@ from aiida.plugins import DataFactory, WorkflowFactory
 from aiida.orm import Dict
 from aiida import cmdline
 
-from . import DATA_DIR
+THIS_DIR = Path(__file__).resolve().parent
+DATA_DIR = THIS_DIR / 'data'
 
 # Workchain objects
 IsothermInflectionWorkChain = WorkflowFactory('lsmo.isotherm_inflection')

--- a/examples/test_IsothermWorkChain_Mg-MOF74.py
+++ b/examples/test_IsothermWorkChain_Mg-MOF74.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Run example isotherm calculation on Mg MOF 74."""
 
+from pathlib import Path
 import os
 import click
 import pytest
@@ -11,7 +12,8 @@ from aiida.plugins import DataFactory, WorkflowFactory
 from aiida.orm import Dict, Str
 from aiida import cmdline
 
-from . import DATA_DIR
+THIS_DIR = Path(__file__).resolve().parent
+DATA_DIR = THIS_DIR / 'data'
 
 # Workchain objects
 IsothermWorkChain = WorkflowFactory('lsmo.isotherm')

--- a/examples/test_MulticompAdsDesWorkChain_HKUST-1.py
+++ b/examples/test_MulticompAdsDesWorkChain_HKUST-1.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Run example two-component isotherm calculation with HKUST1 framework."""
 
+from pathlib import Path
 import os
 import click
 import pytest
@@ -11,7 +12,8 @@ from aiida.plugins import DataFactory, WorkflowFactory
 from aiida.orm import Dict
 from aiida import cmdline
 
-from . import DATA_DIR
+THIS_DIR = Path(__file__).resolve().parent
+DATA_DIR = THIS_DIR / 'data'
 
 # Workchain objects
 MulticompAdsDesWorkChain = WorkflowFactory('lsmo.multicomp_ads_des')  # pylint: disable=invalid-name

--- a/examples/test_SimAnnealingWorkChain_MOF74_CO2.py
+++ b/examples/test_SimAnnealingWorkChain_MOF74_CO2.py
@@ -68,7 +68,7 @@ def cli(raspa_code):
 
     Help: $ ./test_SimAnnealingWorkChain_MOF74_CO2.py --help
     """
-    with open(os.path.join(DATA_DIR, 'Zn-MOF-74.cif.cif'), 'rb') as handle:
+    with open(os.path.join(DATA_DIR, 'Zn-MOF-74.cif'), 'rb') as handle:
         cif = CifData(file=handle)
 
     run_sim_annealing_zn_mof74(raspa_code, cif)

--- a/examples/test_SimAnnealingWorkChain_MOF74_CO2.py
+++ b/examples/test_SimAnnealingWorkChain_MOF74_CO2.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Run example sim annealing of CO2 in Zn-MOF-74 framework."""
 
+from pathlib import Path
 import os
 import click
 import pytest
@@ -11,7 +12,8 @@ from aiida.plugins import DataFactory, WorkflowFactory
 from aiida.orm import Dict, Str
 from aiida import cmdline
 
-from . import DATA_DIR
+THIS_DIR = Path(__file__).resolve().parent
+DATA_DIR = THIS_DIR / 'data'
 
 # Workchain objects
 SimAnnealingWorkChain = WorkflowFactory('lsmo.sim_annealing')  # pylint: disable=invalid-name


### PR DESCRIPTION
according to the discussion in  #85 : 

- define DATA_DIR scripts
- correct example usage
- correct cif label

I tested all of them. They are running now without errors except for the cp2k_multistage protocols. As indicated in issue #88 the output of the MD step is not extracted correctly, so the calculations get excepted