### PR TITLE
Fix eigenvalues parser for CP2K v9

### DIFF
--- a/aiida_lsmo/workchains/isotherm_accurate.py
+++ b/aiida_lsmo/workchains/isotherm_accurate.py
@@ -6,7 +6,7 @@ import functools
 import ruamel.yaml as yaml
 
 from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
-from aiida.orm import Dict, Str, List, SinglefileData
+from aiida.orm import Dict, Str, SinglefileData
 from aiida.engine import calcfunction
 from aiida.engine import WorkChain, ToContext, append_, while_, if_
 from aiida_lsmo.utils import check_resize_unit_cell, dict_merge, validate_dict
@@ -144,7 +144,7 @@ def get_output_parameters(geom_out, inp_params, widom_out=None, **gcmc_out_dict)
                     else:  # when there are no particles and Raspa return Null enthalpy
                         isotherm[label].append(None)
 
-            # TODO: we could finally sort all the values by increasing pressure
+            # TODO: we could finally sort all the values by increasing pressure  # pylint: disable=fixme
 
             out_dict.update({
                 'isotherm': isotherm,
@@ -196,7 +196,9 @@ class IsothermAccurateWorkChain(WorkChain):
             int,
         Required('ph0_reiteration_coeff', default=0.8, description='Coefficient for P_H0 to iterate GCMC at lower P.'):
             NUMBER,
-        Required('p_sat_coeff', default=1, description='Coefficient to push P_sat a little bit more to reach saturation'):
+        Required('p_sat_coeff',
+                 default=1,
+                 description='Coefficient to push P_sat a little bit more to reach saturation'):
             NUMBER,
     })
     parameters_info = parameters_schema.schema  # shorthand for printing
@@ -486,23 +488,24 @@ class IsothermAccurateWorkChain(WorkChain):
         """
         if self.ctx.first_iteration:
             self.ctx.first_iteration = False
-            self.ctx.ph0 = 1 / self.ctx.geom['Unitcell_volume'] / self.ctx.geom[ 'Density'] / 6.022 / self.ctx.kh / 10 
-            # we need to multiply by the cell volume in Angstrom not the POAV and P is in bar now 
+            self.ctx.ph0 = 1 / self.ctx.geom['Unitcell_volume'] / self.ctx.geom['Density'] / 6.022 / self.ctx.kh / 10
+            # we need to multiply by the cell volume in Angstrom not the POAV and P is in bar now
             self.ctx.pressure = self.ctx.ph0
             return True
-        else:
-            self.ctx.gcmc_loading_average = self._get_last_loading_molkg()
-            loading_convergence = (self.ctx.gcmc_loading_average -
-                                   self.ctx.kh * self.ctx.pressure * 100000) / self.ctx.gcmc_loading_average # The pressure is multiplied by 100000 to go from bar to Pa because of Kh
-            if abs(loading_convergence) < self.ctx.parameters['loading_lowp_epsilon']:
-                self.ctx.first_iteration = True
-                if len(self.ctx.raspa_gcmc) > 1:
-                    del self.ctx.raspa_gcmc[0:-1]
-                return False  # Converged!
-            else:
-                self.ctx.pressure *= self.ctx.parameters['ph0_reiteration_coeff']
-                return True  # Not converged: lower P_H0 and recompute GCMC
-    
+
+        self.ctx.gcmc_loading_average = self._get_last_loading_molkg()
+        loading_convergence = (
+            self.ctx.gcmc_loading_average - self.ctx.kh * self.ctx.pressure * 100000
+        ) / self.ctx.gcmc_loading_average  # The pressure is multiplied by 100000 to go from bar to Pa because of Kh
+        if abs(loading_convergence) < self.ctx.parameters['loading_lowp_epsilon']:
+            self.ctx.first_iteration = True
+            if len(self.ctx.raspa_gcmc) > 1:
+                del self.ctx.raspa_gcmc[0:-1]
+            return False  # Converged!
+
+        self.ctx.pressure *= self.ctx.parameters['ph0_reiteration_coeff']
+        return True  # Not converged: lower P_H0 and recompute GCMC
+
     def should_run_another_gcmc_highp(self):
         """Step 4: determine the pressure at which the saturation starts, Psat
         Step 5: After calculating PH and Psat, pressure values in between are generated based on the following
@@ -512,33 +515,36 @@ class IsothermAccurateWorkChain(WorkChain):
         """
         if self.ctx.first_iteration:  # Proceed with first iteration
             self.ctx.first_iteration = False
-            self.ctx.psat = self.ctx.parameters['p_sat_coeff'] * self.ctx.parameters['loading_highp_sigma'] * self.ctx.geom['Estimated_saturation_loading'] / (1 
-                    - self.ctx.parameters['loading_highp_sigma']) / self.ctx.kh / 100000 # the pressure in in bar now
+            self.ctx.psat = self.ctx.parameters['p_sat_coeff'] * self.ctx.parameters[
+                'loading_highp_sigma'] * self.ctx.geom['Estimated_saturation_loading'] / (
+                    1 - self.ctx.parameters['loading_highp_sigma']) / self.ctx.kh / 100000  # the pressure in in bar now
             self.ctx.dpmax = (self.ctx.psat - self.ctx.ph0
                              ) / self.ctx.parameters['n_dpmax']  # Comment: maybe more efficient to use the first ph0
             self.ctx.pressure_old = self.ctx.pressure
-            self.ctx.pressure = self.ctx.pressure_old + 10 * (self.ctx.ph0 / self.ctx.psat) * (self.ctx.geom['Estimated_saturation_loading'] / self.ctx.kh / 100000)
+            self.ctx.pressure = self.ctx.pressure_old + 10 * (self.ctx.ph0 / self.ctx.psat) * (
+                self.ctx.geom['Estimated_saturation_loading'] / self.ctx.kh / 100000)
             self.ctx.gcmc_i += 1
             return True
-        else:
-            gcmc_loading_average_old = self.ctx.gcmc_loading_average
-            self.ctx.gcmc_loading_average = self._get_last_loading_molkg()
-            loading_derivative = (self.ctx.gcmc_loading_average - gcmc_loading_average_old) / (self.ctx.pressure - self.ctx.pressure_old)
-            if loading_derivative < 0:  #Need to recompute GCMC. NOTE: very dangerous, as it can lead to infinite loop!
-                self.report('WARNING: recomputing same pressure point, because loading has negative derivative.')
-                self.ctx.gcmc_loading_average = gcmc_loading_average_old
-                del self.ctx.raspa_gcmc[-1]
-                return True
-            dp_computed = 10 * self.ctx.pressure / self.ctx.psat * self.ctx.geom['Estimated_saturation_loading'] / loading_derivative
-            self.ctx.pressure_old = self.ctx.pressure
-            self.ctx.pressure = self.ctx.pressure_old + min(self.ctx.dpmax, dp_computed)
-            if self.ctx.pressure > self.ctx.psat:
-                return False # Converged
-            else:
-                self.ctx.gcmc_i += 1
-                return True # Didn't converge yet
 
-        return self.ctx.current_p_index < len(self.ctx.pressures)
+        gcmc_loading_average_old = self.ctx.gcmc_loading_average
+        self.ctx.gcmc_loading_average = self._get_last_loading_molkg()
+        loading_derivative = (self.ctx.gcmc_loading_average - gcmc_loading_average_old) / (self.ctx.pressure -
+                                                                                           self.ctx.pressure_old)
+        if loading_derivative < 0:  #Need to recompute GCMC. NOTE: very dangerous, as it can lead to infinite loop!
+            self.report('WARNING: recomputing same pressure point, because loading has negative derivative.')
+            self.ctx.gcmc_loading_average = gcmc_loading_average_old
+            del self.ctx.raspa_gcmc[-1]
+            return True
+        dp_computed = 10 * self.ctx.pressure / self.ctx.psat * self.ctx.geom[
+            'Estimated_saturation_loading'] / loading_derivative
+        self.ctx.pressure_old = self.ctx.pressure
+        self.ctx.pressure = self.ctx.pressure_old + min(self.ctx.dpmax, dp_computed)
+
+        if self.ctx.pressure > self.ctx.psat:
+            return False  # Converged
+
+        self.ctx.gcmc_i += 1
+        return True  # Didn't converge yet
 
     def run_raspa_gcmc(self):
         """Run a GCMC calculation in Raspa @ T,P."""

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,23 +26,23 @@ If you use this plugin for your research, please cite the following work:
 
 If you use AiiDA for your research, please cite the following work:
 
-.. highlights:: **AiiDA >= 1.0:** Sebastiaan. P. Huber, Spyros Zoupanos, Martin Uhrin, Leopold Talirz, 
-  Leonid Kahle, Rico Häuselmann, Dominik Gresch, Tiziano Müller, Aliaksandr V. Yakutovich, Casper W. Andersen, 
-  Francisco F. Ramirez, Carl S. Adorf, Fernando Gargiulo, Snehal Kumbhar, Elsa Passaro, Conrad Johnston, 
-  Andrius Merkys, Andrea Cepellotti, Nicolas Mounet, Nicola Marzari, Boris Kozinsky, and Giovanni Pizzi, 
-  *AiiDA 1.0, a scalable computational infrastructure for automated reproducible workflows and data provenance*, 
+.. highlights:: **AiiDA >= 1.0:** Sebastiaan. P. Huber, Spyros Zoupanos, Martin Uhrin, Leopold Talirz,
+  Leonid Kahle, Rico Häuselmann, Dominik Gresch, Tiziano Müller, Aliaksandr V. Yakutovich, Casper W. Andersen,
+  Francisco F. Ramirez, Carl S. Adorf, Fernando Gargiulo, Snehal Kumbhar, Elsa Passaro, Conrad Johnston,
+  Andrius Merkys, Andrea Cepellotti, Nicolas Mounet, Nicola Marzari, Boris Kozinsky, and Giovanni Pizzi,
+  *AiiDA 1.0, a scalable computational infrastructure for automated reproducible workflows and data provenance*,
   Scientific Data **7**, 300 (2020); DOI: `10.1038/s41597-020-00638-4 <https://doi.org/10.1038/s41597-020-00638-4>`_
 
-.. highlights:: **AiiDA >= 1.0:** Martin Uhrin, Sebastiaan. P. Huber, Jusong Yu, 
-  Nicola Marzari, and Giovanni Pizzi, *Workflows in AiiDA: 
-  Engineering a high-throughput, event-based engine for robust and modular computational workflows*, 
-  Computational Materials Science **187**, 110086 (2021); 
+.. highlights:: **AiiDA >= 1.0:** Martin Uhrin, Sebastiaan. P. Huber, Jusong Yu,
+  Nicola Marzari, and Giovanni Pizzi, *Workflows in AiiDA:
+  Engineering a high-throughput, event-based engine for robust and modular computational workflows*,
+  Computational Materials Science **187**, 110086 (2021);
   DOI: `10.1016/j.commatsci.2020.110086 <https://doi.org/10.1016/j.commatsci.2020.110086>`_
 
-.. highlights:: **AiiDA < 1.0:** Giovanni Pizzi, Andrea Cepellotti, 
-  Riccardo Sabatini, Nicola Marzari, and Boris Kozinsky, 
-  *AiiDA: automated interactive infrastructure and database for computational science*, 
-  Computational Materials Science **111**, 218-230 (2016); 
+.. highlights:: **AiiDA < 1.0:** Giovanni Pizzi, Andrea Cepellotti,
+  Riccardo Sabatini, Nicola Marzari, and Boris Kozinsky,
+  *AiiDA: automated interactive infrastructure and database for computational science*,
+  Computational Materials Science **111**, 218-230 (2016);
   DOI: `10.1016/j.commatsci.2015.09.013 <https://doi.org/10.1016/j.commatsci.2015.09.013>`_
 
 ``aiida-lsmo`` is released under the MIT license.

--- a/examples/run_IsothermAccurateWorkChain_Graphite_Ar.py
+++ b/examples/run_IsothermAccurateWorkChain_Graphite_Ar.py
@@ -7,7 +7,7 @@ import click
 
 from aiida.engine import run
 from aiida.plugins import DataFactory, WorkflowFactory
-from aiida.orm import Code, Dict, Str
+from aiida.orm import Code, Dict
 
 # Workchain objects
 IsothermAccurateWorkChain = WorkflowFactory('lsmo.isotherm_accurate')  # pylint: disable=invalid-name

--- a/examples/run_SinglecompWidomWorkChain_custom.py
+++ b/examples/run_SinglecompWidomWorkChain_custom.py
@@ -6,7 +6,7 @@ import click
 
 from aiida.engine import run
 from aiida.plugins import DataFactory, WorkflowFactory
-from aiida.orm import Str, Dict, load_node
+from aiida.orm import Dict, load_node
 from aiida import cmdline
 
 # Workchain objects

--- a/setup.json
+++ b/setup.json
@@ -13,7 +13,7 @@
     "include_package_data": true,
     "install_requires": [
         "aiida-core~=1.0",
-        "aiida-cp2k>=1.4",
+        "aiida-cp2k~=1.4",
         "aiida-ddec~=1.0",
         "aiida-zeopp~=1.0,>=1.0.3",
         "aiida-raspa~=1.1",
@@ -22,7 +22,8 @@
         "ase<3.20",
         "oximachinerunner~=1.4.0",
         "pymatgen<2021",
-        "phonopy~=2.9"
+        "phonopy~=2.9",
+        "markupsafe<2.1"
     ],
     "entry_points": {
         "aiida.calculations": [

--- a/setup.json
+++ b/setup.json
@@ -13,7 +13,7 @@
     "include_package_data": true,
     "install_requires": [
         "aiida-core~=1.0",
-        "aiida-cp2k~=1.1",
+        "aiida-cp2k>=1.4",
         "aiida-ddec~=1.0",
         "aiida-zeopp~=1.0,>=1.0.3",
         "aiida-raspa~=1.1",


### PR DESCRIPTION
Fix/simplify the eigenvalue parsing for CP2K v9. The main change is the following:

```python
re.search(r'eached convergence', line):
```

since `Reached` is not capitalized anymore in CP2K v9. Other changes are related to
formatting and putting an upper limit on `markupsafe<2.1` since the latest release
broke the docs build.