### PR TITLE
add SL diag library specification in cp2k parameters settings

### DIFF
--- a/examples/run_BindingSiteWorkChain_MOF74_CO2.py
+++ b/examples/run_BindingSiteWorkChain_MOF74_CO2.py
@@ -70,6 +70,9 @@ def main(raspa_code, cp2k_code):
                 'MAX_ITER': 5
             }
         },
+        'GLOBAL': { # Add if you are using version > 7.1
+                'PREFERRED_DIAG_LIBRARY': 'SL'
+        },
     })
 
     run(builder)

--- a/examples/run_BindingSiteWorkChain_MOF74_O2.py
+++ b/examples/run_BindingSiteWorkChain_MOF74_O2.py
@@ -70,6 +70,9 @@ def main(raspa_code, cp2k_code):
                 'MAX_ITER': 5
             }
         },
+        'GLOBAL': { # Add if you are using version > 7.1
+                'PREFERRED_DIAG_LIBRARY': 'SL'
+        },
     })
     builder.starting_settings_idx = int(1)
 

--- a/examples/run_Cp2kMultistageWorkChain_2_H2O.py
+++ b/examples/run_Cp2kMultistageWorkChain_2_H2O.py
@@ -26,13 +26,19 @@ def run_multistage_h2om(cp2k_code):
     structure = StructureData(ase=atoms)
 
     protocol_mod = Dict(dict={'settings_0': {'FORCE_EVAL': {'DFT': {'MGRID': {'CUTOFF': 300,}}}}})
-    parameters = Dict(dict={'FORCE_EVAL': {
-        'DFT': {
-            'UKS': True,
-            'MULTIPLICITY': 3,
-            'CHARGE': -2,
-        }
-    }})
+    parameters = Dict(
+        dict={
+            'FORCE_EVAL': {
+                'DFT': {
+                    'UKS': True,
+                    'MULTIPLICITY': 3,
+                    'CHARGE': -2,
+                },
+            },
+            'GLOBAL': {  # Add if you are using version > 7.1
+                'PREFERRED_DIAG_LIBRARY': 'SL'
+            },
+        })
 
     # Construct process builder
     builder = Cp2kMultistageWorkChain.get_builder()

--- a/examples/run_Cp2kMultistageWorkChain_Cu_HKUST-1.py
+++ b/examples/run_Cp2kMultistageWorkChain_Cu_HKUST-1.py
@@ -29,7 +29,19 @@ def run_multistage_cu_hkust1(cp2k_code, cu_hkust1_structuredata):  # pylint: dis
     """Run Cp2kMultistageWorkChain on Cu-HKUST-1."""
 
     # testing user change of parameters and protocol
-    parameters = Dict(dict={'FORCE_EVAL': {'DFT': {'MGRID': {'CUTOFF': 250,}}}})
+    parameters = Dict(
+        dict={
+            'FORCE_EVAL': {
+                'DFT': {
+                    'MGRID': {
+                        'CUTOFF': 250,
+                    },
+                },
+            },
+            'GLOBAL': {  # Add if you are using version > 7.1
+                'PREFERRED_DIAG_LIBRARY': 'SL'
+            },
+        })
 
     # Construct process builder
     builder = Cp2kMultistageWorkChain.get_builder()

--- a/examples/run_Cp2kMultistageWorkChain_H2O.py
+++ b/examples/run_Cp2kMultistageWorkChain_H2O.py
@@ -5,7 +5,7 @@ import click
 import ase.build
 
 from aiida.engine import run
-from aiida.orm import StructureData, Str
+from aiida.orm import Dict, StructureData, Str
 from aiida.plugins import WorkflowFactory
 from aiida import cmdline
 
@@ -32,6 +32,11 @@ def run_multistage_h2o(cp2k_code):
         'num_mpiprocs_per_machine': 1,
     }
     builder.cp2k_base.cp2k.metadata.options.max_wallclock_seconds = 1 * 3 * 60
+    builder.cp2k_base.cp2k.parameters = Dict(dict={
+        'GLOBAL': {
+            'PREFERRED_DIAG_LIBRARY': 'SL'
+        },
+    })  # add if you are using version > 7.1
 
     run(builder)
 

--- a/examples/run_Cp2kMultistageWorkChain_H2O_fail.py
+++ b/examples/run_Cp2kMultistageWorkChain_H2O_fail.py
@@ -22,12 +22,18 @@ def run_multistage_h2o_fail(cp2k_code):
     atoms.center(vacuum=2.0)
     structure = StructureData(ase=atoms)
 
-    parameters = Dict(dict={'FORCE_EVAL': {
-        'DFT': {
-            'UKS': True,
-            'MULTIPLICITY': 666,
-        }
-    }})
+    parameters = Dict(
+        dict={
+            'FORCE_EVAL': {
+                'DFT': {
+                    'UKS': True,
+                    'MULTIPLICITY': 666,
+                },
+                'GLOBAL': {  # Add if you are using version > 7.1
+                    'PREFERRED_DIAG_LIBRARY': 'SL'
+                },
+            },
+        })
 
     # Construct process builder
     builder = Cp2kMultistageWorkChain.get_builder()

--- a/examples/run_Cp2kMultistageWorkChain_H2O_single_point.py
+++ b/examples/run_Cp2kMultistageWorkChain_H2O_single_point.py
@@ -5,7 +5,7 @@ import click
 import ase.build
 
 from aiida.engine import run
-from aiida.orm import StructureData, Str
+from aiida.orm import Dict, StructureData, Str
 from aiida.plugins import WorkflowFactory
 from aiida import cmdline
 
@@ -32,6 +32,11 @@ def run_multistage_h2o_singlepoint(cp2k_code):
         'num_mpiprocs_per_machine': 1,
     }
     builder.cp2k_base.cp2k.metadata.options.max_wallclock_seconds = 1 * 3 * 60
+    builder.cp2k_base.cp2k.parameters = Dict(dict={
+        'GLOBAL': {
+            'PREFERRED_DIAG_LIBRARY': 'SL'
+        },
+    })  # add if you are using version > 7.1
 
     run(builder)
 

--- a/examples/run_Cp2kMultistageWorkChain_H2O_test_file.py
+++ b/examples/run_Cp2kMultistageWorkChain_H2O_test_file.py
@@ -6,7 +6,7 @@ import click
 import ase.build
 
 from aiida.engine import run
-from aiida.orm import StructureData, SinglefileData
+from aiida.orm import Dict, StructureData, SinglefileData
 from aiida.plugins import WorkflowFactory
 from aiida import cmdline
 
@@ -36,6 +36,11 @@ def run_multistage_h2o_testfile(cp2k_code):
         'num_mpiprocs_per_machine': 1,
     }
     builder.cp2k_base.cp2k.metadata.options.max_wallclock_seconds = 1 * 3 * 60
+    builder.cp2k_base.cp2k.parameters = Dict(dict={
+        'GLOBAL': {
+            'PREFERRED_DIAG_LIBRARY': 'SL'
+        },
+    })  # add if you are using version > 7.1
 
     run(builder)
 

--- a/examples/run_Cp2kPhonopyWorkChain.py
+++ b/examples/run_Cp2kPhonopyWorkChain.py
@@ -4,7 +4,7 @@
 import click
 
 from aiida.engine import run
-from aiida.orm import load_node
+from aiida.orm import Dict, load_node
 from aiida.plugins import WorkflowFactory, DataFactory
 from aiida import cmdline
 
@@ -27,6 +27,11 @@ def run_cp2k_phonopy(cp2k_code, structure_pk):
             'num_mpiprocs_per_machine': 1,
         }
         builder.cp2k_base.cp2k.metadata.options.max_wallclock_seconds = 1 * 3 * 60
+        builder.cp2k_base.cp2k.parameters = Dict(dict={
+            'GLOBAL': {
+                'PREFERRED_DIAG_LIBRARY': 'SL'
+            },
+        })  # add if you are using version > 7.1
 
         run(builder)
 

--- a/examples/test_Cp2kBindingEnergy_CO2_MOF74.py
+++ b/examples/test_Cp2kBindingEnergy_CO2_MOF74.py
@@ -60,6 +60,9 @@ def run_binding_energy_co2_mof74(cp2k_code, zn_mof74, co2_in_mof74):  # pylint: 
                 'MAX_ITER': 5
             }
         },
+        'GLOBAL': { # Add if you are using version > 7.1
+                'PREFERRED_DIAG_LIBRARY': 'SL'
+        },
     })
     builder.cp2k_base.cp2k.code = cp2k_code
     builder.cp2k_base.cp2k.metadata.options.resources = {

--- a/examples/test_Cp2kMultistageDdecWorkChain_H2O.py
+++ b/examples/test_Cp2kMultistageDdecWorkChain_H2O.py
@@ -47,6 +47,11 @@ def run_cp2k_multistage_ddec_h2o(cp2k_code, ddec_code):  # pylint: disable=redef
         'pseudo': SinglefileData(file=str(cp2k_dir / 'GTH_POTENTIALS')),
         'dftd3': SinglefileData(file=str(cp2k_dir / 'dftd3.dat')),
     }
+    builder.cp2k_base.cp2k.parameters = Dict(dict={
+        'GLOBAL': {
+            'PREFERRED_DIAG_LIBRARY': 'SL'
+        },
+    })  # add if you are using version > 7.1
 
     builder.ddec.code = ddec_code
     builder.ddec.parameters = Dict(

--- a/examples/test_Cp2kMultistageWorkChain_Al.py
+++ b/examples/test_Cp2kMultistageWorkChain_Al.py
@@ -35,7 +35,19 @@ def run_multistage_al(cp2k_code, al_structuredata):  # pylint: disable=redefined
     print('EXPECTED: the OT (settings_0) will converge to a negative bandgap, then use SMEARING (settings_1)')
 
     # testing user change of parameters and protocol
-    parameters = Dict(dict={'FORCE_EVAL': {'DFT': {'MGRID': {'CUTOFF': 250,}}}})
+    parameters = Dict(
+        dict={
+            'FORCE_EVAL': {
+                'DFT': {
+                    'MGRID': {
+                        'CUTOFF': 250,
+                    },
+                },
+            },
+            'GLOBAL': {
+                'PREFERRED_DIAG_LIBRARY': 'SL'
+            },  # add if you are using version > 7.1})
+        })
     protocol_mod = Dict(dict={
         'initial_magnetization': {
             'Al': 0


### PR DESCRIPTION
never CP2K versions might run in a deadlock when using the default ELPA library for diagonalization