### PR TITLE
Update cp2k advanced parser

### DIFF
--- a/aiida_lsmo/parsers/parser_functions.py
+++ b/aiida_lsmo/parsers/parser_functions.py
@@ -229,13 +229,13 @@ def parse_cp2k_output_advanced(fstring):  # pylint: disable=too-many-locals, too
                 if re.search(r'Internal Pressure', line):
                     pressure = float(data[4])
             if result_dict['run_type'] == 'MD-NVT':
-                if re.search(r'STEP NUMBER', line):
-                    step = int(data[3])
-                if re.search(r'INITIAL PRESSURE\[bar\]', line):
-                    pressure = float(data[3])
+                if re.search(r'STEP NUMBER', line) or re.search(r'MD\| Step number', line):
+                    step = int(data[-1])
+                if re.search(r'INITIAL PRESSURE\[bar\]', line) or re.search(r'MD_INI\| Pressure', line):
+                    pressure = float(data[-1])
                     print_now = True
-                if re.search(r'PRESSURE \[bar\]', line):
-                    pressure = float(data[3])
+                if re.search(r'PRESSURE \[bar\]', line) or re.search(r'MD\| Pressure', line):
+                    pressure = float(data[-2])
                     print_now = True
             if result_dict['run_type'] == 'MD-NPT_F':  # The two matches are tested for CP2K 5.1 and 8.1
                 if re.search(r'^ STEP NUMBER', line) or re.search(r'^ MD\| Step number', line):

--- a/examples/run_Cp2kMultistageWorkChain_H2O.py
+++ b/examples/run_Cp2kMultistageWorkChain_H2O.py
@@ -5,7 +5,7 @@ import click
 import ase.build
 
 from aiida.engine import run
-from aiida.orm import StructureData, Str
+from aiida.orm import Dict, StructureData, Str
 from aiida.plugins import WorkflowFactory
 from aiida import cmdline
 
@@ -32,6 +32,11 @@ def run_multistage_h2o(cp2k_code):
         'num_mpiprocs_per_machine': 1,
     }
     builder.cp2k_base.cp2k.metadata.options.max_wallclock_seconds = 1 * 3 * 60
+    builder.cp2k_base.cp2k.parameters = Dict(dict={
+        'GLOBAL': {
+            'PREFERRED_DIAG_LIBRARY': 'SL'
+        },
+    })
 
     run(builder)
 

--- a/examples/run_Cp2kMultistageWorkChain_H2O_test_file.py
+++ b/examples/run_Cp2kMultistageWorkChain_H2O_test_file.py
@@ -6,7 +6,7 @@ import click
 import ase.build
 
 from aiida.engine import run
-from aiida.orm import StructureData, SinglefileData
+from aiida.orm import Dict, StructureData, SinglefileData
 from aiida.plugins import WorkflowFactory
 from aiida import cmdline
 
@@ -29,13 +29,18 @@ def run_multistage_h2o_testfile(cp2k_code):
     builder = Cp2kMultistageWorkChain.get_builder()
     builder.structure = structure
     builder.protocol_yaml = SinglefileData(
-        file=os.path.abspath(os.path.join(thisdir, '..', 'data', 'test_multistage_protocol.yaml')))
+        file=os.path.abspath(os.path.join(thisdir, 'data', 'test_multistage_protocol.yaml')))
     builder.cp2k_base.cp2k.code = cp2k_code
     builder.cp2k_base.cp2k.metadata.options.resources = {
         'num_machines': 1,
         'num_mpiprocs_per_machine': 1,
     }
     builder.cp2k_base.cp2k.metadata.options.max_wallclock_seconds = 1 * 3 * 60
+    builder.cp2k_base.cp2k.parameters = Dict(dict={
+        'GLOBAL': {
+            'PREFERRED_DIAG_LIBRARY': 'SL'
+        },
+    })
 
     run(builder)
 


### PR DESCRIPTION
Update Cp2k-Parser to include output of MD runs for CP2K 9.1. Tested on CP2K-7.1 and CP2K-9.1