### PR TITLE
Update sim annealing

### DIFF
--- a/aiida_lsmo/calcfunctions/ff_data.yaml
+++ b/aiida_lsmo/calcfunctions/ff_data.yaml
@@ -1020,3 +1020,63 @@ Xe:
         pseudo_atom: [yes, Xe, Xe, 0, 131.29, 0.0, 0.0, 1.0, 1.0, 0, 0, relative, 0]
     atomic_positions:
     - [Xe_gas 0, 0, 0]
+
+DMA:
+  critical_constants:
+    tc: 710.35
+    pc: 5712000
+    af: 0.227
+  BOYDCM5:
+    description: Dispersion parameters from https://doi.org/10.1038/s41467-019-09486-2, CM5 charges
+    atom_types:
+      N1_dma:
+        force_field: [lennard-jones, 38.9492, 3.263]
+        pseudo_atom: [yes, N, N, 0, 14.0067, -0.4285, 0.0, 1.0, 0.7, 0, 0, relative, 0]
+      C1_dma:
+        force_field: [lennard-jones, 47.8562, 3.473]
+        pseudo_atom: [yes, C, C, 0, 12.00, -0.0885, 0.0, 1.0, 1.0, 0, 0, relative, 0]
+      H1_dma:
+        force_field: [lennard-jones, 7.6489, 2.846]
+        pseudo_atom: [yes, H, H, 0, 1.01, 0.1429, 0.0, 1.0, 1.0, 0, 0, relative, 0]
+      H2_dma:
+        force_field: [lennard-jones, 7.6489, 2.846]
+        pseudo_atom: [yes, H, H, 0, 1.01, 0.3741, 0.0, 1.0, 1.0, 0, 0, relative, 0]
+    atomic_positions:
+    - [N1_dma, 0.00000, 0.54187, 0.00000]
+    - [C1_dma, 1.26604, -0.27620, 0.00000]
+    - [C1_dma, -1.26604, -0.27620, 0.00000]
+    - [H1_dma, 1.27256, -0.90337, 0.89907]
+    - [H1_dma, 2.12803, 0.40147, 0.00000]
+    - [H1_dma, 1.27256, -0.90336, -0.89907]
+    - [H1_dma, -2.12803, 0.40146, -0.00004]
+    - [H1_dma, -1.27252, -0.90340, -0.89905]
+    - [H1_dma, -1.27256, -0.90334, 0.89909]
+    - [H2_dma, 0.00000, 1.16590, -0.82196]
+    - [H2_dma, 0.00000, 1.16589, 0.82197]
+  BOYDDDEC:
+    description: Dispersion parameters from https://doi.org/10.1038/s41467-019-09486-2, DDEC charges
+    atom_types:
+      N1_dma:
+        force_field: [lennard-jones, 38.9492, 3.263]
+        pseudo_atom: [yes, N, N, 0, 14.0067, -0.0670, 0.0, 1.0, 0.7, 0, 0, relative, 0]
+      C1_dma:
+        force_field: [lennard-jones, 47.8562, 3.473]
+        pseudo_atom: [yes, C, C, 0, 12.00, -0.2592, 0.0, 1.0, 1.0, 0, 0, relative, 0]
+      H1_dma:
+        force_field: [lennard-jones, 7.6489, 2.846]
+        pseudo_atom: [yes, H, H, 0, 1.01, 0.1624, 0.0, 1.0, 1.0, 0, 0, relative, 0]
+      H2_dma:
+        force_field: [lennard-jones, 7.6489, 2.846]
+        pseudo_atom: [yes, H, H, 0, 1.01, 0.3055, 0.0, 1.0, 1.0, 0, 0, relative, 0]
+    atomic_positions:
+    - [N1_dma, 0.0000, 0.0000, 0.0000]
+    - [C1_dma, -1.2645, -0.8099, 0.0000]
+    - [C1_dma, 1.2645, -0.8098, 0.0000]
+    - [H1_dma, -1.2787, -1.4431, 0.9054]
+    - [H1_dma, -2.1330, -0.1266, -0.0009]
+    - [H1_dma, -1.2778, -1.4450, -0.9040]
+    - [H1_dma, 2.1330, -0.1267, -0.0009]
+    - [H1_dma, 1.2786, -1.4433, 0.9053]
+    - [H1_dma, 1.2777, -1.4451, -0.9040]
+    - [H2_dma, 0.0000, 0.6334, 0.8221]
+    - [H2_dma, -0.0000, 0.6315, -0.8235]

--- a/aiida_lsmo/workchains/sim_annealing.py
+++ b/aiida_lsmo/workchains/sim_annealing.py
@@ -36,15 +36,17 @@ def get_molecule_from_restart_file(structure_cif, molecule_folderdata, input_dic
 
     # Get the atom types of the molecule (ASE accepts only atomic eilements as "symbols")
     ff_data_molecule = load_yaml()[molecule_dict['name']][molecule_dict['forcefield']]
-    symbolsff = [x[0].split('_')[0] for x in ff_data_molecule['atomic_positions']]
+    symbolsff = [x[0] for x in ff_data_molecule['atomic_positions']]
 
     symbolsff *= number_of_molecules
+    chem = [ff_data_molecule['atom_types'][atom]['pseudo_atom'][2] for atom in symbolsff]
 
     # Get the coordinates of the molecule from restart-file in the extended unit cell
-    restart_fname = molecule_folderdata.list_object_names(os.path.join('Restart', 'System_0'))[0]  # pylint: disable=protected-access
-    fobj = molecule_folderdata.get_object_content(os.path.join('Restart', 'System_0', restart_fname))  # pylint: disable=protected-access
+    fobj = molecule_folderdata.get_object_content(
+        os.path.join('Restart', 'System_0',
+                     molecule_folderdata.list_object_names(os.path.join('Restart', 'System_0'))[0]))  # pylint: disable=protected-access
     lines_positions = [line.split()[3:6] for line in fobj.splitlines() if 'Adsorbate-atom-position:' in line]
-    symbols_positions = list(zip(symbolsff, lines_positions))
+    symbols_positions = list(zip(chem, lines_positions))
     symbols_positions = [(name, position) for name, position in symbols_positions if name != 'M'
                         ]  # Removing dummy atoms.
     symbols, positions = list(zip(*symbols_positions))

--- a/examples/run_SimAnnealingWorkChain_HKUST-1_3xDMA.py
+++ b/examples/run_SimAnnealingWorkChain_HKUST-1_3xDMA.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Run example sim annealing of 3 CO2 molecules in HKUST-1 framework."""
+
+import os
+import click
+
+from aiida.engine import run
+from aiida.plugins import DataFactory, WorkflowFactory
+from aiida.orm import Dict
+from aiida import cmdline
+
+# Workchain objects
+SimAnnealingWorkChain = WorkflowFactory('lsmo.sim_annealing')  # pylint: disable=invalid-name
+
+# Data objects
+CifData = DataFactory('cif')  # pylint: disable=invalid-name
+
+
+@click.command('cli')
+@cmdline.utils.decorators.with_dbenv()
+@click.option('--raspa_code', type=cmdline.params.types.CodeParamType())
+def main(raspa_code):
+    """Prepare inputs and submit the work chain."""
+
+    builder = SimAnnealingWorkChain.get_builder()
+    builder.metadata.label = 'test'
+    builder.raspa_base.raspa.code = raspa_code
+    builder.raspa_base.raspa.metadata.options = {
+        'resources': {
+            'num_machines': 1,
+            'tot_num_mpiprocs': 1,
+        },
+        'max_wallclock_seconds': 1 * 60 * 60,
+    }
+    builder.structure = CifData(file=os.path.abspath('data/HKUST-1.cif'), label='HKUST-1')
+    builder.molecule = Dict(dict={
+        'name': 'DMA',
+        'forcefield': 'BOYDDDEC',
+        'proberad': 1.7365,
+        'singlebead': False,
+        'charged': True,
+    })
+    builder.parameters = Dict(
+        dict={
+            'ff_framework': 'UFF',  # (str) Forcefield of the structure.
+            'temperature_list': [300, 150],  # (list) List of decreasing temperatures for the annealing.
+            'mc_steps': int(10),  # (int) Number of MC cycles.
+            'number_of_molecules': 3  # (int) Number of molecules loaded in the framework.
+        })
+
+    run(builder)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter
+
+# EOF


### PR DESCRIPTION
Currently, the simannealing workchain fails to extract the molecule coordinates from the RASPA restart file when the force field contains specific labels that are not chemical symbols. I updated the parsing to directly extract the chemical symbol from the `ff_data.yaml` file. Dummies are ignored (if labeled M) but the workchain will still fail for FF containing united atoms